### PR TITLE
Move Intel accelerators into the host provider

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -461,7 +461,7 @@ jobs:
 
   publish-intel-provider:
     needs: build
-    uses: reefyai/reefy-intel/.github/workflows/publish.yml@6467ed0f4cc0376b5769800147ce192fb8d83aa3
+    uses: reefyai/reefy-intel/.github/workflows/publish.yml@dd364f3897ae6c97455c389db8d9fb7982af2296
     with:
       input_artifact: reefy-intel-inputs
     secrets: inherit

--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -216,6 +216,13 @@ jobs:
             echo "in-tree AMD provider module leaked into the Reefy OS image"
             exit 1
           fi
+          if find "$module_dir" \
+              \( -name 'i915.ko*' -o -name 'xe.ko*' \
+                 -o -name 'intel_vpu.ko*' -o -name 'kvmgt.ko*' \) \
+              -print -quit | grep -q .; then
+            echo "Intel provider modules leaked into the Reefy OS image"
+            exit 1
+          fi
           for helper in drm_suballoc_helper drm_panel_backlight_quirks; do
             find "$module_dir" -name "${helper}.ko*" | grep -q . \
               || { echo "missing shared DRM helper ${helper}"; exit 1; }
@@ -238,13 +245,31 @@ jobs:
             echo "NVIDIA provider libraries leaked into the Reefy OS image"
             exit 1
           fi
+          for path in \
+              "$BR_OUTPUT/target/lib/firmware/i915" \
+              "$BR_OUTPUT/target/lib/firmware/xe" \
+              "$BR_OUTPUT/target/lib/firmware/intel/vpu"; do
+            if [ -e "$path" ]; then
+              echo "Intel provider firmware leaked into the Reefy OS image: $path"
+              exit 1
+            fi
+          done
 
       - name: Verify multi-flavor outputs
         run: |
-          test -f "$BR_OUTPUT/target/lib/firmware/xe/lnl_guc_70.bin" \
-            || { echo "missing xe/lnl_guc_70.bin"; exit 1; }
-          test -f "$BR_OUTPUT/target/lib/firmware/i915/xe2lpd_dmc.bin" \
-            || { echo "missing i915/xe2lpd_dmc.bin"; exit 1; }
+          intel="$BR_OUTPUT/reefy-artifacts/intel"
+          for module in i915 xe intel_vpu; do
+            find "$intel/modules-root" -name "${module}.ko*" | grep -q . \
+              || { echo "missing Intel provider module ${module}"; exit 1; }
+          done
+          test -f "$intel/firmware-root/lib/firmware/xe/lnl_guc_70.bin" \
+            || { echo "missing Intel provider xe/lnl_guc_70.bin"; exit 1; }
+          test -f "$intel/firmware-root/lib/firmware/i915/xe2lpd_dmc.bin" \
+            || { echo "missing Intel provider i915/xe2lpd_dmc.bin"; exit 1; }
+          find "$intel/firmware-root/lib/firmware/intel/vpu" \
+            -name 'vpu_*.bin' | grep -q . \
+            || { echo "missing Intel provider VPU firmware"; exit 1; }
+          du -h "$intel/modules-root" "$intel/firmware-root"
           ls -la "$BR_OUTPUT/images/"
           for flavor in prod dev debug-shell; do
             test -f "$BR_OUTPUT/images/reefy-${flavor}.efi" \
@@ -292,7 +317,14 @@ jobs:
           EOF
 
           intel="$BR_OUTPUT/reefy-artifacts/intel"
-          mkdir -p "$intel"
+          for module in i915 xe intel_vpu; do
+            find "$intel/modules-root/lib/modules/$kernel_release" \
+              -name "${module}.ko*" | grep -q . \
+              || { echo "missing Intel provider input ${module}"; exit 1; }
+          done
+          test -d "$intel/firmware-root/lib/firmware/i915"
+          test -d "$intel/firmware-root/lib/firmware/xe"
+          test -d "$intel/firmware-root/lib/firmware/intel/vpu"
           cp "$nvidia/metadata.env" "$intel/metadata.env"
 
           amd="$BR_OUTPUT/reefy-artifacts/amd"
@@ -344,7 +376,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: reefy-intel-inputs
-          path: ${{ env.BR_OUTPUT }}/reefy-artifacts/intel/metadata.env
+          compression-level: 1
+          path: |
+            ${{ env.BR_OUTPUT }}/reefy-artifacts/intel/modules-root
+            ${{ env.BR_OUTPUT }}/reefy-artifacts/intel/firmware-root
+            ${{ env.BR_OUTPUT }}/reefy-artifacts/intel/metadata.env
 
       - name: Upload AMD provider inputs
         uses: actions/upload-artifact@v4
@@ -425,7 +461,7 @@ jobs:
 
   publish-intel-provider:
     needs: build
-    uses: reefyai/reefy-intel/.github/workflows/publish.yml@e1d0b67643663cfbf24ce0eb0d2de82f2935e0d2
+    uses: reefyai/reefy-intel/.github/workflows/publish.yml@6467ed0f4cc0376b5769800147ce192fb8d83aa3
     with:
       input_artifact: reefy-intel-inputs
     secrets: inherit

--- a/board/reefy/reefy/post_build.sh
+++ b/board/reefy/reefy/post_build.sh
@@ -208,19 +208,6 @@ for license in LICENSE.i915 LICENSE.xe; do
   cp "${LINUX_FIRMWARE_BUILD}/${license}" \
     "${INTEL_FIRMWARE}/usr/share/licenses/intel-provider/${license}"
 done
-NPU_LICENSE=''
-for candidate in LICENSE.intel_vpu LICENSE.intel; do
-  if [ -f "${INTEL_NPU_FIRMWARE_BUILD}/${candidate}" ]; then
-    NPU_LICENSE="${INTEL_NPU_FIRMWARE_BUILD}/${candidate}"
-    break
-  fi
-done
-if [ -z "${NPU_LICENSE}" ]; then
-  echo "ERROR: missing Intel VPU firmware license" >&2
-  exit 1
-fi
-cp "${NPU_LICENSE}" \
-  "${INTEL_FIRMWARE}/usr/share/licenses/intel-provider/${NPU_LICENSE##*/}"
 
 # NVIDIA packages in the Buildroot configuration produce exact inputs for the
 # external provider artifact. None of their driver payload belongs in the

--- a/board/reefy/reefy/post_build.sh
+++ b/board/reefy/reefy/post_build.sh
@@ -150,6 +150,67 @@ if [ -n "${PINNED_KERNEL}" ] && [ -d "${TARGET_DIR}/lib/modules" ]; then
     ! -name "${PINNED_KERNEL}" -exec rm -rf {} +
 fi
 
+# Stage Intel GPU and NPU inputs from the exact kernel and firmware package
+# build trees before removing their vendor-specific payload from Reefy OS.
+# Reading the build trees, rather than TARGET_DIR, keeps incremental builds
+# reproducible after a previous post-build pass has already pruned the files.
+INTEL_STAGE="${BASE_DIR}/reefy-artifacts/intel"
+INTEL_MODULES="${INTEL_STAGE}/modules-root/lib/modules/${PINNED_KERNEL}/extra/intel"
+INTEL_FIRMWARE="${INTEL_STAGE}/firmware-root"
+LINUX_FIRMWARE_VERSION=$(sed -n \
+  's/^LINUX_FIRMWARE_VERSION = \(.*\)$/\1/p' \
+  "${BR2_EXTERNAL_REEFY_PATH}/buildroot/package/linux-firmware/linux-firmware.mk")
+INTEL_NPU_FIRMWARE_VERSION=$(sed -n \
+  's/^INTEL_NPU_FIRMWARE_VERSION = \(.*\)$/\1/p' \
+  "${BR2_EXTERNAL_REEFY_PATH}/package/intel-npu-firmware/intel-npu-firmware.mk")
+LINUX_FIRMWARE_BUILD="${BUILD_DIR}/linux-firmware-${LINUX_FIRMWARE_VERSION}"
+INTEL_NPU_FIRMWARE_BUILD="${BUILD_DIR}/intel-npu-firmware-${INTEL_NPU_FIRMWARE_VERSION}"
+rm -rf "${INTEL_STAGE}"
+mkdir -p "${INTEL_MODULES}" \
+  "${INTEL_FIRMWARE}/lib/firmware/i915" \
+  "${INTEL_FIRMWARE}/lib/firmware/xe" \
+  "${INTEL_FIRMWARE}/lib/firmware/intel/vpu" \
+  "${INTEL_FIRMWARE}/usr/share/licenses/intel-provider"
+
+for module in \
+    "${LINUX_BUILD_DIR}/drivers/gpu/drm/i915/i915.ko" \
+    "${LINUX_BUILD_DIR}/drivers/gpu/drm/xe/xe.ko" \
+    "${LINUX_BUILD_DIR}/drivers/accel/ivpu/intel_vpu.ko"; do
+  if [ ! -f "${module}" ]; then
+    echo "ERROR: missing Intel provider module ${module}" >&2
+    exit 1
+  fi
+  cp "${module}" "${INTEL_MODULES}/"
+done
+if [ -f "${LINUX_BUILD_DIR}/drivers/gpu/drm/i915/kvmgt.ko" ]; then
+  cp "${LINUX_BUILD_DIR}/drivers/gpu/drm/i915/kvmgt.ko" \
+    "${INTEL_MODULES}/"
+fi
+for module in "${INTEL_MODULES}"/*.ko; do
+  "${HOST_DIR}/bin/x86_64-buildroot-linux-gnu-strip" --strip-debug "${module}"
+done
+
+for directory in i915 xe; do
+  if [ ! -d "${LINUX_FIRMWARE_BUILD}/${directory}" ]; then
+    echo "ERROR: missing Intel firmware directory ${directory}" >&2
+    exit 1
+  fi
+  cp -a "${LINUX_FIRMWARE_BUILD}/${directory}/." \
+    "${INTEL_FIRMWARE}/lib/firmware/${directory}/"
+done
+if [ ! -d "${INTEL_NPU_FIRMWARE_BUILD}/intel/vpu" ]; then
+  echo "ERROR: missing Intel VPU firmware input" >&2
+  exit 1
+fi
+cp -a "${INTEL_NPU_FIRMWARE_BUILD}/intel/vpu/." \
+  "${INTEL_FIRMWARE}/lib/firmware/intel/vpu/"
+for license in LICENSE.i915 LICENSE.xe; do
+  cp "${LINUX_FIRMWARE_BUILD}/${license}" \
+    "${INTEL_FIRMWARE}/usr/share/licenses/intel-provider/${license}"
+done
+cp "${INTEL_NPU_FIRMWARE_BUILD}/LICENSE.intel_vpu" \
+  "${INTEL_FIRMWARE}/usr/share/licenses/intel-provider/LICENSE.intel_vpu"
+
 # NVIDIA packages in the Buildroot configuration produce exact inputs for the
 # external provider artifact. None of their driver payload belongs in the
 # immutable Reefy OS image. Remove stale files from incremental TARGET_DIR
@@ -183,7 +244,18 @@ if [ -d "${TARGET_DIR}/lib/modules" ]; then
   # kernel ABI used by the separately published AMD 31.40 provider. Never
   # ship that older in-tree driver beside the external provider module.
   find "${TARGET_DIR}/lib/modules" -type f -name 'amdgpu.ko*' -delete
+  # Intel GPU and NPU modules are staged above for the exact-build provider.
+  # Shared DRM helpers remain in the base OS for all vendors.
+  find "${TARGET_DIR}/lib/modules" -type f \
+    \( -name 'i915.ko*' -o -name 'xe.ko*' -o -name 'intel_vpu.ko*' \
+       -o -name 'kvmgt.ko*' \) -delete
   find "${TARGET_DIR}/lib/modules" -depth -type d -empty -delete
+fi
+rm -rf "${TARGET_DIR}/lib/firmware/i915" \
+       "${TARGET_DIR}/lib/firmware/xe" \
+       "${TARGET_DIR}/lib/firmware/intel/vpu"
+if [ -d "${TARGET_DIR}/lib/firmware/intel" ]; then
+  find "${TARGET_DIR}/lib/firmware/intel" -depth -type d -empty -delete
 fi
 if [ -n "${PINNED_KERNEL}" ] && [ -x "${HOST_DIR}/sbin/depmod" ]; then
   "${HOST_DIR}/sbin/depmod" -a -b "${TARGET_DIR}" "${PINNED_KERNEL}"

--- a/board/reefy/reefy/post_build.sh
+++ b/board/reefy/reefy/post_build.sh
@@ -208,8 +208,19 @@ for license in LICENSE.i915 LICENSE.xe; do
   cp "${LINUX_FIRMWARE_BUILD}/${license}" \
     "${INTEL_FIRMWARE}/usr/share/licenses/intel-provider/${license}"
 done
-cp "${INTEL_NPU_FIRMWARE_BUILD}/LICENSE.intel_vpu" \
-  "${INTEL_FIRMWARE}/usr/share/licenses/intel-provider/LICENSE.intel_vpu"
+NPU_LICENSE=''
+for candidate in LICENSE.intel_vpu LICENSE.intel; do
+  if [ -f "${INTEL_NPU_FIRMWARE_BUILD}/${candidate}" ]; then
+    NPU_LICENSE="${INTEL_NPU_FIRMWARE_BUILD}/${candidate}"
+    break
+  fi
+done
+if [ -z "${NPU_LICENSE}" ]; then
+  echo "ERROR: missing Intel VPU firmware license" >&2
+  exit 1
+fi
+cp "${NPU_LICENSE}" \
+  "${INTEL_FIRMWARE}/usr/share/licenses/intel-provider/${NPU_LICENSE##*/}"
 
 # NVIDIA packages in the Buildroot configuration produce exact inputs for the
 # external provider artifact. None of their driver payload belongs in the

--- a/board/reefy/reefy/tests/test_provider_workflow.py
+++ b/board/reefy/reefy/tests/test_provider_workflow.py
@@ -30,7 +30,7 @@ class ProviderWorkflowTests(unittest.TestCase):
             'reefyai/reefy-nvidia':
                 'bae37235695f797f86c05efc06daa0b927752a19',
             'reefyai/reefy-intel':
-                'e1d0b67643663cfbf24ce0eb0d2de82f2935e0d2',
+                '6467ed0f4cc0376b5769800147ce192fb8d83aa3',
             'reefyai/reefy-amd':
                 'ccaf743c5dd77af5aaab91ee8300d1d5402ee1f9',
             'reefyai/reefy-artifact-fixtures':
@@ -47,3 +47,24 @@ class ProviderWorkflowTests(unittest.TestCase):
             self.assertEqual(
                 _checkout_ref(workflow, repository),
                 _workflow_ref(workflow, repository))
+
+    def test_intel_provider_receives_modules_and_firmware(self):
+        workflow = WORKFLOW.read_text()
+
+        self.assertIn(
+            '${{ env.BR_OUTPUT }}/reefy-artifacts/intel/modules-root',
+            workflow)
+        self.assertIn(
+            '${{ env.BR_OUTPUT }}/reefy-artifacts/intel/firmware-root',
+            workflow)
+        self.assertIn('for module in i915 xe intel_vpu; do', workflow)
+        self.assertIn('missing Intel provider input ${module}', workflow)
+
+    def test_intel_payload_is_rejected_from_base_image(self):
+        workflow = WORKFLOW.read_text()
+
+        self.assertIn('Intel provider modules leaked', workflow)
+        self.assertIn('Intel provider firmware leaked', workflow)
+        self.assertIn("-name 'i915.ko*'", workflow)
+        self.assertIn("-name 'xe.ko*'", workflow)
+        self.assertIn("-name 'intel_vpu.ko*'", workflow)

--- a/board/reefy/reefy/tests/test_provider_workflow.py
+++ b/board/reefy/reefy/tests/test_provider_workflow.py
@@ -30,7 +30,7 @@ class ProviderWorkflowTests(unittest.TestCase):
             'reefyai/reefy-nvidia':
                 'bae37235695f797f86c05efc06daa0b927752a19',
             'reefyai/reefy-intel':
-                '6467ed0f4cc0376b5769800147ce192fb8d83aa3',
+                'dd364f3897ae6c97455c389db8d9fb7982af2296',
             'reefyai/reefy-amd':
                 'ccaf743c5dd77af5aaab91ee8300d1d5402ee1f9',
             'reefyai/reefy-artifact-fixtures':


### PR DESCRIPTION
## Summary
- move Intel GPU and NPU modules and firmware out of the immutable base image
- package Intel activation and firmware licenses in the build-matched provider artifact
- extend provider workflow coverage for Intel payloads

## Validation
- successful push firmware build 30907669313
- dev firmware 2026.08.04-02 published successfully
- dev golden-path E2E passed, including two fresh branch firmware builds and A/B updates
- real Intel GPU and NPU hardware gates passed before promotion