### PR TITLE
Recover failed app projects after long Compose pulls

### DIFF
--- a/board/reefy/reefy/rootfs-overlay/usr/lib/reefy/reefy/dataplane.py
+++ b/board/reefy/reefy/rootfs-overlay/usr/lib/reefy/reefy/dataplane.py
@@ -10,10 +10,14 @@ a publish failure can never abort the work.
 """
 
 import base64
+import codecs
+from collections import deque
 import hashlib
 import json
 import os
 import re
+import selectors
+import signal
 import shutil
 import subprocess
 import sys
@@ -195,6 +199,11 @@ class DataPlane:
     # nor a reconciler restart / reboot re-pulls a doomed (multi-GB) image
     # again. Cleared on a changed compose or a successful apply.
     _FAILED_SIG_PATH = '/mnt/reefy-data/state/.failed-compose-sig'
+    COMPOSE_PULL_BUDGET_SECONDS = 3600
+    COMPOSE_PULL_MAX_ATTEMPTS = 5
+    COMPOSE_START_TIMEOUT_SECONDS = 180
+    COMPOSE_OUTPUT_TAIL_LINES = 200
+    COMPOSE_OUTPUT_LINE_CHARS = 4000
     _DEV_INJECTED_KEY_PATH = '/mnt/reefy/reefy/dev/authorized_keys'
     _FILES_ALLOWED_ROOTS = (
         '/mnt/reefy-data/apps/',
@@ -262,11 +271,21 @@ class DataPlane:
             expired = self._runtime_error_order.pop(0)
             self._runtime_result_errors.pop(expired, None)
 
-    def _submit_apply_job(self, kind, state=None):
+    def _submit_apply_job(
+            self, kind, state=None, force_retry=None, wait_for_idle=False):
         """Persist and enqueue one apply, replacing only the pending job."""
         request_id = str(uuid_mod.uuid4())
-        job = {'request_id': request_id, 'kind': kind, 'state': state}
+        job = {
+            'request_id': request_id,
+            'kind': kind,
+            'state': state,
+            'force_retry': force_retry,
+        }
         with self._job_condition:
+            while (wait_for_idle
+                   and (self._running_job is not None
+                        or self._pending_job is not None)):
+                self._job_condition.wait()
             if not self._apply_results.create(request_id, kind):
                 return {
                     'ok': False,
@@ -317,7 +336,8 @@ class DataPlane:
                     ok = self._apply_state({'state': job['state']})
                 else:
                     applied = os.path.exists(self._active_state_path())
-                    ok = self._apply_desired_state()
+                    ok = self._apply_desired_state(
+                        force_retry=job.get('force_retry'))
                 warnings = list(self._last_apply_warnings)
                 if ok is False:
                     status = 'failed'
@@ -520,6 +540,54 @@ class DataPlane:
         except Exception as e:
             log('mqtt', f'Backup error: {e}')
 
+    def _retry_pending_migration_app(self, app, compose, failed_record):
+        """Retry one failed preflight through the serialized full handoff."""
+        instance_uuid = app.get('instance_uuid') or ''
+        project_name = app.get('project_name') or ''
+        primary_service = app.get('primary_service') or 'app'
+        retry_intent = {
+            'project_name': project_name,
+            'signature': failed_record.get('signature') or '',
+        }
+        submitted = self._submit_apply_job(
+            'reconcile', force_retry=retry_intent, wait_for_idle=True)
+        if not submitted.get('ok'):
+            raise RuntimeError(
+                submitted.get('error')
+                or 'could not enqueue migration retry')
+        log('mqtt', f'Queued migration retry for {project_name}')
+        result = self._wait_apply_result(submitted['request_id'])
+        latest_state = self._read_json(self._active_state_path())
+        latest_app = None
+        if self._is_v2_state(latest_state):
+            latest_app = next((
+                candidate for candidate in latest_state.get('apps') or []
+                if (candidate.get('instance_uuid') == instance_uuid
+                    and candidate.get('project_name') == project_name)), None)
+        current_failure = {}
+        if latest_app is not None:
+            latest_compose = json.loads(json.dumps(
+                latest_app.get('compose') or {}))
+            _drop_absent_devices(latest_compose)
+            _drop_unavailable_cdi_devices(latest_compose)
+            current_failure = self._current_required_app_failure(
+                project_name, latest_compose,
+                latest_app.get('primary_service') or 'app')
+        retry_succeeded = (
+            result.get('status') in ('succeeded', 'succeeded_with_warnings')
+            and not self._v2_migration_pending()
+            and latest_app is not None
+            and latest_app.get('desired_status') == 'running'
+            and not current_failure)
+        if retry_succeeded:
+            return f'Instance {instance_uuid} restarted'
+
+        reason = (
+            current_failure.get('reason')
+            or result.get('error')
+            or 'migration retry did not complete')
+        raise RuntimeError(reason)
+
     def _restart_instance(self, payload, cmd_id=None):
         """Recreate an app instance container with current config.
 
@@ -549,12 +617,62 @@ class DataPlane:
                 raise RuntimeError('App project not found')
             project_name = app.get('project_name') or ''
             compose_path = self._project_compose_path(project_name)
+            compose = json.loads(json.dumps(app.get('compose') or {}))
+            for _service, host_path in _drop_absent_devices(compose):
+                log('reconciler',
+                    f'{project_name}: skipping absent device {host_path}')
+            for _service, resource in _drop_unavailable_cdi_devices(compose):
+                log('reconciler',
+                    f'{project_name}: skipping unavailable CDI resource '
+                    f'{resource}')
             with self._project_lock(project_name):
+                failed_record = self._current_required_app_failure(
+                    project_name, compose,
+                    app.get('primary_service') or 'app')
+            if self._v2_migration_pending():
+                if not failed_record:
+                    raise RuntimeError(
+                        'Apps-v2 migration is in progress; retry later')
+                return self._retry_pending_migration_app(
+                    app, compose, failed_record)
+
+            with self._project_lock(project_name):
+                failed_record = self._current_required_app_failure(
+                    project_name, compose,
+                    app.get('primary_service') or 'app')
+                if failed_record:
+                    log('mqtt',
+                        f'Retrying failed app project {project_name}')
+                    if not self._prepare_app_artifacts(app):
+                        self._publish_health_status(
+                            instance_uuid, 'failed',
+                            message='artifact prepare failed')
+                        raise RuntimeError('artifact prepare failed')
+                    ok, _optional_failures = (
+                        self._apply_app_project_compose(
+                            project_name, compose,
+                            instance_uuid=instance_uuid,
+                            primary_service=(
+                                app.get('primary_service') or 'app'),
+                            force_retry=True))
+                    if not ok:
+                        current = self._read_failed_sig_record(
+                            os.path.join(
+                                self.PROJECTS_DIR, project_name,
+                                '.failed-compose-sig'))
+                        raise RuntimeError(
+                            current.get('reason')
+                            or 'app project recovery failed')
+                    log('mqtt',
+                        f'App project {project_name} recovered')
+                    return f'Instance {svc_id} restarted'
+
                 result = subprocess.run(
                     ['docker', 'compose', '-f', compose_path, '-p',
                      project_name, 'up', '-d', '--force-recreate',
                      '--no-deps', app.get('primary_service') or 'app'],
-                    capture_output=True, text=True, timeout=180)
+                    capture_output=True, text=True,
+                    timeout=self.COMPOSE_START_TIMEOUT_SECONDS)
                 if result.returncode != 0:
                     raise RuntimeError(
                         result.stderr.strip()
@@ -630,7 +748,7 @@ class DataPlane:
         # applying/ready stages around its Varlink call.
         return self._apply_desired_state(old_state=old_state)
 
-    def _apply_desired_state(self, old_state=None):
+    def _apply_desired_state(self, old_state=None, force_retry=None):
         """Load saved desired state and apply it (hostname, compose, proxy).
         If no desired state exists, reset hostname to MAC-based default.
         old_state: previous desired state for diff-based cleanup (None on boot).
@@ -740,7 +858,8 @@ class DataPlane:
         # monolithic path below unchanged.
         if v2_state is not None:
             project_failures = self._apply_v2_projects(
-                v2_state, failed_restores=failed_restores)
+                v2_state, failed_restores=failed_restores,
+                force_retry=force_retry)
             self._last_apply_warnings.extend(project_failures)
 
         # Write legacy compose file and run the monolithic project.
@@ -817,7 +936,41 @@ class DataPlane:
 
         return True
 
-    def _apply_v2_projects(self, state, failed_restores=None):
+    def _publish_migration_legacy_running(
+            self, state, legacy_compose, instance_uuids):
+        """Restore terminal health for legacy apps left or put back live."""
+        instance_uuids = set(instance_uuids or ())
+        legacy_services = legacy_compose.get('services') or {}
+        for app in state.get('apps') or []:
+            instance_uuid = app.get('instance_uuid') or ''
+            if (instance_uuid not in instance_uuids
+                    or app.get('desired_status') != 'running'
+                    or instance_uuid not in legacy_services):
+                continue
+            image = (legacy_services.get(instance_uuid) or {}).get('image')
+            self._publish_health_status(
+                instance_uuid, 'running', image=image)
+
+    def _publish_migration_v2_running(self, state, prepared_apps):
+        """Publish one committed terminal event for each running v2 app."""
+        for app in state.get('apps') or []:
+            instance_uuid = app.get('instance_uuid') or ''
+            prepared = prepared_apps.get(instance_uuid)
+            if (prepared is None
+                    or app.get('desired_status') != 'running'):
+                continue
+            terminal = prepared.get('_running_health') or {}
+            image = terminal.get('image')
+            if image is None:
+                primary_service = app.get('primary_service') or 'app'
+                image = ((app.get('compose') or {}).get('services') or {}).get(
+                    primary_service, {}).get('image')
+            self._publish_health_status(
+                instance_uuid, 'running',
+                message=terminal.get('message'), image=image)
+
+    def _apply_v2_projects(
+            self, state, failed_restores=None, force_retry=None):
         """Reconcile the system project, then all app projects concurrently.
 
         Returns structured ApplyWarning records. A project failure does not
@@ -834,6 +987,7 @@ class DataPlane:
         system_compose = system.get('compose') or {'services': {}}
         migration = self._v2_migration_pending()
         migration_failed = False
+        failed_app_ids = set()
         legacy_compose = self._read_json(self.COMPOSE_PATH) if migration else {}
         legacy_instances = {
             row.get('instance_uuid')
@@ -846,29 +1000,97 @@ class DataPlane:
             if name not in legacy_instances
         ]
 
-        if migration and not self._prepare_v2_system_handoff(
-                system_name, system_compose, legacy_system_services):
-            warnings.append({
-                'code': 'system_project_failed',
-                'instance_uuid': '',
-                'volume': '',
-            })
-            self._rollback_v2_migration(state, system_name)
-            self._reset_artifact_retry()
-            return warnings
-
-        if not self._apply_project_compose(
-                system_name, system_compose, instance_uuid=None):
-            migration_failed = True
-            warnings.append({
-                'code': 'system_project_failed',
-                'instance_uuid': '',
-                'volume': '',
-            })
-            if migration:
-                self._rollback_v2_migration(state, system_name)
+        apps = list(state.get('apps') or [])
+        prepared_apps = {}
+        if migration:
+            # Migration is a two-phase handoff. Pull every required image
+            # while the complete legacy project is still running, then
+            # release names and start the already-prepared v2 projects.
+            prepared_system = self._prepare_system_project_compose(
+                system_name, system_compose, migration=True)
+            if not prepared_system.get('ok'):
+                warnings.append({
+                    'code': 'system_project_failed',
+                    'instance_uuid': '',
+                    'volume': '',
+                })
                 self._reset_artifact_retry()
                 return warnings
+
+            if apps:
+                with ThreadPoolExecutor(max_workers=len(apps)) as pool:
+                    futures = {}
+                    for app in apps:
+                        restore_failed = (
+                            app.get('instance_uuid') in failed_restores)
+                        if (force_retry
+                                and force_retry.get('project_name')
+                                == app.get('project_name')):
+                            future = pool.submit(
+                                self._prepare_v2_app, app, restore_failed,
+                                force_retry=force_retry)
+                        else:
+                            future = pool.submit(
+                                self._prepare_v2_app, app, restore_failed)
+                        futures[future] = app
+                    for future in as_completed(futures):
+                        app = futures[future]
+                        try:
+                            ok, code, prepared = future.result()
+                        except Exception as exception:
+                            ok = False
+                            code = (
+                                'app_project_exception_'
+                                f'{type(exception).__name__}')
+                            prepared = None
+                            log('reconciler',
+                                f'{app.get("project_name")}: {code}')
+                        if ok:
+                            prepared_apps[
+                                app.get('instance_uuid') or ''] = prepared
+                            continue
+                        migration_failed = True
+                        failed_app_ids.add(app.get('instance_uuid') or '')
+                        warnings.append({
+                            'code': code or 'app_project_failed',
+                            'instance_uuid': app.get('instance_uuid') or '',
+                            'volume': '',
+                        })
+            if migration_failed:
+                self._publish_migration_legacy_running(
+                    state, legacy_compose, prepared_apps)
+                if any(
+                        warning.get('code') == 'artifact_prepare_failed'
+                        for warning in warnings):
+                    self._schedule_artifact_retry()
+                else:
+                    self._reset_artifact_retry()
+                return warnings
+
+            def system_handoff():
+                return self._prepare_v2_system_handoff(
+                    system_name, system_compose,
+                    legacy_system_services)
+
+            if not self._start_prepared_system_project(
+                    prepared_system, before_start=system_handoff):
+                warnings.append({
+                    'code': 'system_project_failed',
+                    'instance_uuid': '',
+                    'volume': '',
+                })
+                if self._rollback_v2_migration(state, system_name):
+                    self._publish_migration_legacy_running(
+                        state, legacy_compose, prepared_apps)
+                self._reset_artifact_retry()
+                return warnings
+        elif not self._apply_project_compose(
+                system_name, system_compose, instance_uuid=None):
+            warnings.append({
+                'code': 'system_project_failed',
+                'instance_uuid': '',
+                'volume': '',
+            })
 
         desired_projects = {
             app.get('project_name') for app in (state.get('apps') or [])
@@ -876,13 +1098,14 @@ class DataPlane:
         }
         self._remove_absent_v2_projects(desired_projects)
 
-        apps = list(state.get('apps') or [])
         if apps:
             with ThreadPoolExecutor(max_workers=len(apps)) as pool:
                 futures = {
                     pool.submit(
                         self._reconcile_v2_app, app, migration,
-                        app.get('instance_uuid') in failed_restores): app
+                        app.get('instance_uuid') in failed_restores,
+                        prepared_apps.get(
+                            app.get('instance_uuid') or '')): app
                     for app in apps
                 }
                 for future in as_completed(futures):
@@ -902,6 +1125,8 @@ class DataPlane:
                         code, optional_failures = outcome, []
                     if not ok:
                         migration_failed = True
+                        failed_app_ids.add(
+                            app.get('instance_uuid') or '')
                         warnings.append({
                             'code': code or 'app_project_failed',
                             'instance_uuid': app.get('instance_uuid') or '',
@@ -915,9 +1140,23 @@ class DataPlane:
 
         if migration:
             if migration_failed:
-                self._rollback_v2_migration(state, system_name)
+                if self._rollback_v2_migration(state, system_name):
+                    self._publish_migration_legacy_running(
+                        state, legacy_compose,
+                        set(prepared_apps) - failed_app_ids)
             else:
-                self._commit_v2_migration()
+                if not self._commit_v2_migration():
+                    warnings.append({
+                        'code': 'system_project_failed',
+                        'instance_uuid': '',
+                        'volume': '',
+                    })
+                    if self._rollback_v2_migration(state, system_name):
+                        self._publish_migration_legacy_running(
+                            state, legacy_compose, prepared_apps)
+                else:
+                    self._publish_migration_v2_running(
+                        state, prepared_apps)
         if any(
                 warning.get('code') == 'artifact_prepare_failed'
                 for warning in warnings):
@@ -936,53 +1175,70 @@ class DataPlane:
         only legacy system services here. Legacy app containers stay stopped
         at their individual final handoffs and remain available for rollback.
         """
-        compose_path = self._write_project_compose(
-            system_name, system_compose)
+        with self._project_lock(system_name):
+            compose_path = self._write_project_compose(
+                system_name, system_compose)
 
-        # Remove debris from a prior partial attempt before releasing the
-        # working legacy services. This is safe because migration has not
-        # committed and the legacy compose file remains authoritative.
-        ok, output = self._run_compose_command(
-            compose_path, system_name, ['rm', '-s', '-f'], timeout=180)
-        if not ok:
-            reason = self._failure_reason(
-                self._classify_compose_failure(output), output)
-            log('reconciler',
-                f'{system_name}: could not remove partial system project: '
-                f'{reason}')
-            return False
-
-        if legacy_system_services:
-            ok, _ = self._run_compose_command(
-                self.COMPOSE_PATH, 'state',
-                ['stop', *legacy_system_services], timeout=180)
+            # Remove debris from a prior partial attempt before releasing the
+            # working legacy services. This is safe because migration has not
+            # committed and the legacy compose file remains authoritative.
+            ok, output = self._run_compose_command(
+                compose_path, system_name, ['rm', '-s', '-f'], timeout=180)
             if not ok:
-                return False
-            ok, _ = self._run_compose_command(
-                self.COMPOSE_PATH, 'state',
-                ['rm', '-f', *legacy_system_services], timeout=180)
-            if not ok:
+                reason = self._failure_reason(
+                    self._classify_compose_failure(output), output)
+                log('reconciler',
+                    f'{system_name}: could not remove partial system '
+                    f'project: {reason}')
                 return False
 
-        # A previous name collision may have cached this exact Compose
-        # signature as failed. Removing the legacy containers changes the
-        # runtime precondition, so the same desired Compose must be retried.
-        self._clear_project_failed_sigs(system_name)
-        return True
+            if legacy_system_services:
+                ok, _ = self._run_compose_command(
+                    self.COMPOSE_PATH, 'state',
+                    ['stop', *legacy_system_services], timeout=180)
+                if not ok:
+                    return False
+                ok, _ = self._run_compose_command(
+                    self.COMPOSE_PATH, 'state',
+                    ['rm', '-f', *legacy_system_services], timeout=180)
+                if not ok:
+                    return False
+
+            # A previous name collision may have cached this exact Compose
+            # signature as failed. Releasing the legacy names changes the
+            # runtime precondition, so allow the prepared v2 start to retry.
+            self._clear_project_failed_sigs(system_name)
+            return True
 
     def _rollback_v2_migration(self, state, system_name):
         """Restore the monolithic v1 project after a handoff failure."""
+        cleanup_failures = []
         for app in state.get('apps') or []:
             project_name = app.get('project_name') or ''
             compose_path = self._project_compose_path(project_name)
             if project_name and os.path.exists(compose_path):
-                self._run_compose_command(
-                    compose_path, project_name, ['stop'], timeout=180)
+                with self._project_lock(project_name):
+                    ok, output = self._run_compose_command(
+                        compose_path, project_name, ['stop'], timeout=180)
+                    if not ok:
+                        cleanup_failures.append(
+                            f'{project_name}: '
+                            f'{self._bounded_output_tail(output, "stop failed")}')
 
         system_path = self._project_compose_path(system_name)
         if os.path.exists(system_path):
-            self._run_compose_command(
-                system_path, system_name, ['rm', '-s', '-f'], timeout=180)
+            with self._project_lock(system_name):
+                ok, output = self._run_compose_command(
+                    system_path, system_name, ['rm', '-s', '-f'], timeout=180)
+                if not ok:
+                    cleanup_failures.append(
+                        f'{system_name}: '
+                        f'{self._bounded_output_tail(output, "remove failed")}')
+
+        if cleanup_failures:
+            log('reconciler',
+                'Apps-v2 rollback cleanup failures: '
+                + ' | '.join(cleanup_failures))
 
         ok, output = self._run_compose_command(
             self.COMPOSE_PATH, 'state',
@@ -991,22 +1247,24 @@ class DataPlane:
             reason = self._failure_reason(
                 self._classify_compose_failure(output), output)
             log('reconciler', f'Apps-v2 migration rollback failed: {reason}')
-        return ok
+        return ok and not cleanup_failures
 
     def _clear_project_failed_sigs(self, project_name):
-        project_dir = os.path.dirname(self._project_compose_path(project_name))
-        try:
-            entries = os.scandir(project_dir)
-        except OSError:
-            return
-        with entries:
-            for entry in entries:
-                if not entry.name.startswith('.failed-compose-sig'):
-                    continue
-                try:
-                    os.unlink(entry.path)
-                except FileNotFoundError:
-                    pass
+        with self._project_lock(project_name):
+            project_dir = os.path.dirname(
+                self._project_compose_path(project_name))
+            try:
+                entries = os.scandir(project_dir)
+            except OSError:
+                return
+            with entries:
+                for entry in entries:
+                    if not entry.name.startswith('.failed-compose-sig'):
+                        continue
+                    try:
+                        os.unlink(entry.path)
+                    except FileNotFoundError:
+                        pass
 
     def _schedule_artifact_retry(self):
         """Queue one exponential, event-driven retry for unavailable bytes.
@@ -1043,15 +1301,15 @@ class DataPlane:
             if timer is not None:
                 timer.cancel()
 
-    def _reconcile_v2_app(self, app, migration, restore_failed):
+    def _prepare_v2_app(self, app, restore_failed, force_retry=None):
         instance_uuid = app.get('instance_uuid') or ''
         project_name = app.get('project_name') or ''
         if not instance_uuid or not project_name:
-            return False, 'invalid_app_project'
+            return False, 'invalid_app_project', None
         if restore_failed:
             self._publish_health_status(
                 instance_uuid, 'failed', message='restore failed')
-            return False, 'restore_failed'
+            return False, 'restore_failed', None
 
         compose = json.loads(json.dumps(app.get('compose') or {}))
         for _service, host_path in _drop_absent_devices(compose):
@@ -1059,39 +1317,86 @@ class DataPlane:
                 f'{project_name}: skipping absent device {host_path}')
 
         if app.get('desired_status') == 'stopped':
-            if migration:
-                self._run_compose_command(
-                    self.COMPOSE_PATH, 'state', ['stop', instance_uuid],
-                    timeout=180)
-            self._write_project_compose(project_name, compose)
-            ok, _ = self._run_compose_command(
-                self._project_compose_path(project_name), project_name,
-                ['stop'], timeout=180)
-            return ok, '' if ok else 'app_stop_failed'
+            return True, '', {
+                'ok': True,
+                'stopped': True,
+                'project_name': project_name,
+                'compose': compose,
+                'instance_uuid': instance_uuid,
+            }
 
         if not self._prepare_app_artifacts(app):
-            return False, 'artifact_prepare_failed'
+            self._publish_health_status(
+                instance_uuid, 'failed',
+                message='artifact prepare failed')
+            return False, 'artifact_prepare_failed', None
 
         for _service, resource in _drop_unavailable_cdi_devices(compose):
             log('reconciler',
                 f'{project_name}: skipping unavailable CDI resource '
                 f'{resource}')
 
-        # Keep a runnable legacy service alive while its new image or host
-        # artifact prepares. Stop it only at the final per-app handoff.
-        if migration:
-            self._run_compose_command(
-                self.COMPOSE_PATH, 'state', ['stop', instance_uuid],
-                timeout=180)
-
-        ok, optional_failures = self._apply_app_project_compose(
+        prepared = self._prepare_app_project_compose(
             project_name, compose, instance_uuid=instance_uuid,
-            primary_service=app.get('primary_service') or 'app')
-        if not ok and migration:
-            self._run_compose_command(
-                self.COMPOSE_PATH, 'state', ['start', instance_uuid],
-                timeout=180)
-        return ok, ('' if ok else 'app_project_failed', optional_failures)
+            primary_service=app.get('primary_service') or 'app',
+            force_retry=bool(force_retry),
+            force_retry_signature=(
+                force_retry.get('signature') if force_retry else None))
+        if not prepared.get('ok'):
+            return False, prepared.get('code') or 'app_project_failed', None
+        return True, '', prepared
+
+    def _reconcile_v2_app(
+            self, app, migration, restore_failed, prepared=None):
+        instance_uuid = app.get('instance_uuid') or ''
+        project_name = app.get('project_name') or ''
+        if prepared is None:
+            ok, code, prepared = self._prepare_v2_app(
+                app, restore_failed)
+            if not ok:
+                return False, code
+
+        with self._project_lock(project_name):
+            if prepared.get('stopped'):
+                if migration:
+                    ok, _ = self._run_compose_command(
+                        self.COMPOSE_PATH, 'state',
+                        ['stop', instance_uuid], timeout=180)
+                    if not ok:
+                        return False, 'app_stop_failed'
+                self._write_project_compose(
+                    project_name, prepared['compose'])
+                ok, _ = self._run_compose_command(
+                    self._project_compose_path(project_name), project_name,
+                    ['stop'], timeout=180)
+                return ok, '' if ok else 'app_stop_failed'
+
+            # Keep a runnable legacy service alive through artifact and image
+            # preparation. Stop it only when startup can use cached images.
+            if migration:
+                ok, output = self._run_compose_command(
+                    self.COMPOSE_PATH, 'state', ['stop', instance_uuid],
+                    timeout=180)
+                if not ok:
+                    reason = 'legacy app stop failed'
+                    context = prepared.get('required_context')
+                    if context:
+                        self._write_failed_sig_path(
+                            context['path'], context['signature'], reason,
+                            phase='start', services=context['services'])
+                    self._publish_health_status(
+                        instance_uuid, 'failed',
+                        message=self._bounded_output_tail(output, reason))
+                    return False, 'app_stop_failed'
+
+            ok, optional_failures = self._start_prepared_app_project(
+                prepared, publish_running=not migration)
+            if not ok and migration:
+                self._run_compose_command(
+                    self.COMPOSE_PATH, 'state', ['start', instance_uuid],
+                    timeout=180)
+            return ok, (
+                '' if ok else 'app_project_failed', optional_failures)
 
     def _prepare_app_artifacts(self, app):
         artifacts = app.get('artifacts') or []
@@ -1152,6 +1457,111 @@ class DataPlane:
         labels = service.get('labels') or {}
         return labels.get('ai.reefy.optional') == 'true'
 
+    @staticmethod
+    def _service_dependencies(service):
+        depends_on = service.get('depends_on') or {}
+        if isinstance(depends_on, dict):
+            return list(depends_on)
+        if isinstance(depends_on, list):
+            return list(depends_on)
+        return []
+
+    def _service_closure(self, compose, roots, excluded=None):
+        """Return roots and their declared dependencies in stable order."""
+        services = compose.get('services') or {}
+        excluded = set(excluded or ())
+        pending = list(roots or ())
+        result = set()
+        while pending:
+            service_name = pending.pop()
+            if (service_name in result or service_name in excluded
+                    or service_name not in services):
+                continue
+            result.add(service_name)
+            pending.extend(self._service_dependencies(services[service_name]))
+        return sorted(result)
+
+    @staticmethod
+    def _compose_without_services(compose, removed_services):
+        """Copy Compose while removing services and references to them."""
+        result = json.loads(json.dumps(compose))
+        services = result.get('services') or {}
+        removed_services = set(removed_services or ())
+        for name in removed_services:
+            services.pop(name, None)
+        for service in services.values():
+            depends_on = service.get('depends_on')
+            if isinstance(depends_on, dict):
+                service['depends_on'] = {
+                    name: value for name, value in depends_on.items()
+                    if name not in removed_services
+                }
+                if not service['depends_on']:
+                    service.pop('depends_on')
+            elif isinstance(depends_on, list):
+                service['depends_on'] = [
+                    name for name in depends_on
+                    if name not in removed_services]
+                if not service['depends_on']:
+                    service.pop('depends_on')
+        return result
+
+    def _init_service_signature(self, service_name, service):
+        return self._compose_sig({
+            'service': service_name,
+            'definition': service,
+        })
+
+    def _completed_init_services(self, project_name, compose):
+        project_dir = os.path.dirname(
+            self._project_compose_path(project_name))
+        completed = set()
+        for service_name, service in (
+                compose.get('services') or {}).items():
+            if self._service_lifecycle(service) != 'init':
+                continue
+            signature = self._init_service_signature(
+                service_name, service)
+            try:
+                with open(os.path.join(
+                        project_dir,
+                        f'.init-{service_name}.sig')) as stream:
+                    if stream.read().strip() == signature:
+                        completed.add(service_name)
+            except OSError:
+                pass
+        return completed
+
+    def _ordered_pending_init_services(
+            self, compose, completed, skipped_optional):
+        services = compose.get('services') or {}
+        pending = {
+            name for name, service in services.items()
+            if self._service_lifecycle(service) == 'init'
+            and name not in completed
+            and name not in skipped_optional
+        }
+        ordered = []
+        visiting = set()
+        visited = set()
+
+        def visit(service_name):
+            if service_name in visited or service_name not in pending:
+                return
+            if service_name in visiting:
+                return
+            visiting.add(service_name)
+            for dependency in self._service_dependencies(
+                    services[service_name]):
+                visit(dependency)
+            visiting.remove(service_name)
+            visited.add(service_name)
+            ordered.append(service_name)
+
+        for service_name in services:
+            visit(service_name)
+        return ordered
+
     def _runtime_app_compose(self, compose):
         """Remove completed init definitions from the long-running project.
 
@@ -1159,113 +1569,538 @@ class DataPlane:
         Compose file excludes them after fingerprinted execution so a later
         Compose or Docker restart cannot accidentally rerun an init job.
         """
-        runtime = json.loads(json.dumps(compose))
-        services = runtime.get('services') or {}
+        services = compose.get('services') or {}
         init_names = {
             name for name, service in services.items()
             if self._service_lifecycle(service) == 'init'
         }
-        for name in init_names:
-            services.pop(name, None)
-        for service in services.values():
-            depends_on = service.get('depends_on')
-            if isinstance(depends_on, dict):
-                service['depends_on'] = {
-                    name: value for name, value in depends_on.items()
-                    if name not in init_names
-                }
-                if not service['depends_on']:
-                    service.pop('depends_on')
-            elif isinstance(depends_on, list):
-                service['depends_on'] = [
-                    name for name in depends_on if name not in init_names]
-                if not service['depends_on']:
-                    service.pop('depends_on')
-        return runtime
+        return self._compose_without_services(compose, init_names)
 
     def _run_app_init_services(
-            self, project_name, compose, instance_uuid):
-        failures = []
-        compose_path = self._write_project_compose(project_name, compose)
-        project_dir = os.path.dirname(compose_path)
-        for service_name, service in (compose.get('services') or {}).items():
-            if self._service_lifecycle(service) != 'init':
-                continue
-            signature = self._compose_sig({
-                'service': service_name,
-                'definition': service,
-            })
-            signature_path = os.path.join(
-                project_dir, f'.init-{service_name}.sig')
-            try:
-                with open(signature_path) as stream:
-                    if stream.read().strip() == signature:
+            self, project_name, compose, instance_uuid,
+            skipped_optional=None, required_init_services=None):
+        """Run changed init services without allowing an implicit pull.
+
+        Returns (required_ok, optional_failures, required_failure), where
+        failure values retain the bounded Compose diagnostic output.
+        """
+        skipped_optional = set(skipped_optional or ())
+        if required_init_services is None:
+            required_init_services = {
+                name for name, service in (
+                    compose.get('services') or {}).items()
+                if (self._service_lifecycle(service) == 'init'
+                    and not self._service_is_optional(service))
+            }
+        else:
+            required_init_services = set(required_init_services)
+        optional_failures = {}
+        with self._project_lock(project_name):
+            services = compose.get('services') or {}
+            completed = self._completed_init_services(
+                project_name, compose)
+            ordered = self._ordered_pending_init_services(
+                compose, completed, skipped_optional)
+            execution_compose = self._compose_without_services(
+                compose, completed | skipped_optional)
+            project_dir = os.path.dirname(
+                self._project_compose_path(project_name))
+            for service_name in ordered:
+                service = services[service_name]
+                compose_path = self._write_project_compose(
+                    project_name, execution_compose)
+                signature = self._init_service_signature(
+                    service_name, service)
+                signature_path = os.path.join(
+                    project_dir, f'.init-{service_name}.sig')
+                self._publish_health_status(
+                    instance_uuid, 'starting',
+                    message=f'running init service {service_name}')
+                ok, output = self._run_compose_command(
+                    compose_path, project_name,
+                    ['run', '--pull', 'never', '--rm', service_name],
+                    timeout=1800)
+                if not ok:
+                    log('reconciler',
+                        f'{project_name}: init service {service_name} failed')
+                    if (self._service_is_optional(service)
+                            and service_name not in required_init_services):
+                        optional_failures[service_name] = output
+                        execution_compose = self._compose_without_services(
+                            execution_compose, [service_name])
                         continue
-            except OSError:
-                pass
-            self._publish_health_status(
-                instance_uuid, 'starting',
-                message=f'running init service {service_name}')
-            ok, output = self._run_compose_command(
-                compose_path, project_name,
-                ['run', '--rm', service_name], timeout=1800)
-            if not ok:
-                log('reconciler',
-                    f'{project_name}: init service {service_name} failed')
-                if self._service_is_optional(service):
-                    failures.append(service_name)
+                    return False, optional_failures, (
+                        service_name, output)
+                temporary = f'{signature_path}.tmp'
+                with open(temporary, 'w') as stream:
+                    stream.write(f'{signature}\n')
+                    stream.flush()
+                    os.fsync(stream.fileno())
+                os.replace(temporary, signature_path)
+                execution_compose = self._compose_without_services(
+                    execution_compose, [service_name])
+        return True, optional_failures, None
+
+    def _app_project_plan(self, project_name, compose, primary_service):
+        runtime = self._runtime_app_compose(compose)
+        all_services = compose.get('services') or {}
+        runtime_services = runtime.get('services') or {}
+        completed_init = self._completed_init_services(
+            project_name, compose)
+        required_init = [
+            name for name, service in all_services.items()
+            if self._service_lifecycle(service) == 'init'
+            and not self._service_is_optional(service)
+            and name not in completed_init
+        ]
+        optional_init = [
+            name for name, service in all_services.items()
+            if self._service_lifecycle(service) == 'init'
+            and self._service_is_optional(service)
+            and name not in completed_init
+        ]
+        required_runtime = [
+            name for name, service in runtime_services.items()
+            if not self._service_is_optional(service)
+        ]
+        if primary_service not in required_runtime:
+            return None
+
+        required_services = set(self._service_closure(
+            compose, required_init + required_runtime,
+            excluded=completed_init))
+        required_init_services = {
+            name for name in required_services
+            if self._service_lifecycle(all_services[name]) == 'init'
+        }
+
+        optional = []
+        for kind, names, source in (
+                ('init', optional_init, compose),
+                ('runtime', [
+                    name for name, service in runtime_services.items()
+                    if self._service_is_optional(service)], runtime)):
+            for service_name in names:
+                if service_name in required_services:
                     continue
-                return False, failures
-            temporary = f'{signature_path}.tmp'
-            with open(temporary, 'w') as stream:
-                stream.write(f'{signature}\n')
-                stream.flush()
-                os.fsync(stream.fileno())
-            os.replace(temporary, signature_path)
-        return True, failures
+                optional.append({
+                    'kind': kind,
+                    'name': service_name,
+                    'services': self._service_closure(
+                        (compose if kind == 'runtime' else source),
+                        [service_name], excluded=completed_init),
+                    'init_dependencies': {
+                        dependency for dependency in self._service_closure(
+                            compose, [service_name],
+                            excluded=completed_init)
+                        if (dependency != service_name
+                            and self._service_lifecycle(
+                                all_services[dependency]) == 'init')
+                    },
+                })
+        return {
+            'runtime': runtime,
+            'required_init': required_init,
+            'required_runtime': required_runtime,
+            'required_services': sorted(required_services),
+            'required_init_services': required_init_services,
+            'completed_init': completed_init,
+            'optional': optional,
+        }
+
+    def _required_app_failure_context(
+            self, project_name, compose, primary_service, plan=None):
+        plan = plan or self._app_project_plan(
+            project_name, compose, primary_service)
+        if plan is None:
+            return None
+        legacy_required = [
+            name for name, service in (
+                plan['runtime'].get('services') or {}).items()
+            if not self._service_is_optional(service)
+        ]
+        legacy_signature = self._compose_sig({
+            'compose': plan['runtime'],
+            'services': legacy_required,
+        })
+        return self._failure_marker_context(
+            project_name, compose, plan['required_services'],
+            compatible_signatures=[legacy_signature])
+
+    def _current_required_app_failure(
+            self, project_name, compose, primary_service):
+        """Return the current unsuffixed required-project failure only."""
+        path = os.path.join(
+            self.PROJECTS_DIR, project_name, '.failed-compose-sig')
+        record = self._read_failed_sig_record(path)
+        if not record:
+            return {}
+        if record.get('version') == 2 and record.get('services'):
+            current_signature = self._compose_sig({
+                'compose': compose,
+                'services': sorted(record['services']),
+            })
+            if current_signature == record.get('signature'):
+                return record
+        context = self._required_app_failure_context(
+            project_name, compose, primary_service)
+        if context and record.get('signature') in context['signatures']:
+            return record
+        return {}
+
+    def _failure_marker_context(
+            self, project_name, compose, services=None,
+            failure_suffix='', compatible_signatures=None):
+        service_names = sorted(set(
+            services if services is not None
+            else (compose.get('services') or {})))
+        if services is None:
+            signature = self._compose_sig(compose)
+        else:
+            signature = self._compose_sig({
+                'compose': compose,
+                'services': service_names,
+            })
+        failed_name = '.failed-compose-sig'
+        if failure_suffix:
+            safe_suffix = re.sub(
+                r'[^A-Za-z0-9_.-]', '_', failure_suffix)
+            failed_name += f'.{safe_suffix}'
+        path = os.path.join(
+            self.PROJECTS_DIR, project_name, failed_name)
+        signatures = {signature}
+        signatures.update(compatible_signatures or ())
+        return {
+            'path': path,
+            'signature': signature,
+            'signatures': signatures,
+            'services': service_names,
+        }
+
+    def _matching_failed_record(self, context):
+        record = self._read_failed_sig_record(context['path'])
+        if record.get('signature') in context['signatures']:
+            return record
+        return {}
+
+    @classmethod
+    def _bounded_output_tail(cls, output, fallback=''):
+        lines = (output or '').splitlines()
+        safe_fallback = shared.redact_log_message(fallback) if fallback else ''
+        if safe_fallback:
+            tail = [safe_fallback, *lines[-4:]]
+        else:
+            tail = lines[-5:]
+        return '\n'.join(
+            shared.redact_log_message(line)[:cls.COMPOSE_OUTPUT_LINE_CHARS]
+            for line in tail)
+
+    def _prepare_app_project_compose(
+            self, project_name, compose, instance_uuid, primary_service,
+            force_retry=False, force_retry_signature=None):
+        """Write and explicitly pull every app image before any startup."""
+        with self._project_lock(project_name):
+            plan = self._app_project_plan(
+                project_name, compose, primary_service)
+            if plan is None:
+                self._publish_health_status(
+                    instance_uuid, 'failed',
+                    message='primary service is not required')
+                return {'ok': False, 'code': 'app_project_failed'}
+
+            compose_path = self._write_project_compose(project_name, compose)
+            required_context = self._required_app_failure_context(
+                project_name, compose, primary_service, plan=plan)
+            failed_record = self._current_required_app_failure(
+                project_name, compose, primary_service)
+            if (force_retry and failed_record
+                    and (force_retry_signature is None
+                         or failed_record.get('signature')
+                         == force_retry_signature)):
+                self._clear_project_failed_sigs(project_name)
+                failed_record = {}
+            if failed_record:
+                reason = failed_record.get('reason') or 'app startup failed'
+                self._publish_health_status(
+                    instance_uuid, 'failed', message=reason)
+                return {
+                    'ok': False,
+                    'code': 'app_project_failed',
+                    'failed_record': failed_record,
+                }
+
+            self._publish_health_status(instance_uuid, 'starting')
+            pull_deadline = (
+                time.monotonic() + self.COMPOSE_PULL_BUDGET_SECONDS)
+            ok, output, reason = self._pull_project_images(
+                compose_path, project_name, plan['required_services'],
+                pull_deadline, max_retries=self.COMPOSE_PULL_MAX_ATTEMPTS)
+            if not ok:
+                self._write_failed_sig_path(
+                    required_context['path'], required_context['signature'],
+                    reason, phase='pull',
+                    services=required_context['services'])
+                self._publish_health_status(
+                    instance_uuid, 'failed',
+                    message=self._bounded_output_tail(output, reason))
+                return {'ok': False, 'code': 'app_project_failed'}
+
+            optional_failures = {}
+            optional_ready = set()
+            optional_contexts = {}
+            for optional in plan['optional']:
+                service_name = optional['name']
+                compatible_signatures = []
+                if optional['kind'] == 'runtime':
+                    compatible_signatures.append(self._compose_sig({
+                        'compose': plan['runtime'],
+                        'services': [service_name],
+                    }))
+                context = self._failure_marker_context(
+                    project_name, compose, optional['services'],
+                    failure_suffix=f'optional-{service_name}',
+                    compatible_signatures=compatible_signatures)
+                optional_contexts[service_name] = context
+                failed_record = self._matching_failed_record(context)
+                if failed_record:
+                    optional_failures[service_name] = (
+                        failed_record.get('reason')
+                        or 'optional service failed')
+                    continue
+                unavailable_init = []
+                if optional['kind'] == 'runtime':
+                    unavailable_init = sorted(
+                        dependency
+                        for dependency in optional['init_dependencies']
+                        if (dependency
+                            not in plan['required_init_services']
+                            and dependency not in optional_ready))
+                if unavailable_init:
+                    reason = 'optional init dependency unavailable'
+                    optional_failures[service_name] = reason
+                    self._write_failed_sig_path(
+                        context['path'], context['signature'], reason,
+                        phase='pull', services=context['services'])
+                    continue
+                ok, output, reason = self._pull_project_images(
+                    compose_path, project_name, optional['services'],
+                    pull_deadline, max_retries=1)
+                if not ok:
+                    optional_failures[service_name] = output or reason
+                    self._write_failed_sig_path(
+                        context['path'], context['signature'], reason,
+                        phase='pull', services=context['services'])
+                    continue
+                optional_ready.add(service_name)
+
+            return {
+                'ok': True,
+                'project_name': project_name,
+                'compose': compose,
+                'compose_path': compose_path,
+                'instance_uuid': instance_uuid,
+                'primary_service': primary_service,
+                'plan': plan,
+                'required_context': required_context,
+                'optional_contexts': optional_contexts,
+                'optional_ready': optional_ready,
+                'optional_failures': optional_failures,
+            }
+
+    def _start_prepared_app_project(self, prepared, publish_running=True):
+        project_name = prepared['project_name']
+        instance_uuid = prepared['instance_uuid']
+        compose = prepared['compose']
+        plan = prepared['plan']
+        required_context = prepared['required_context']
+        optional_failures = dict(prepared['optional_failures'])
+        optional_contexts = prepared['optional_contexts']
+        optional_ready = prepared['optional_ready']
+        with self._project_lock(project_name):
+            skipped_optional = {
+                optional['name'] for optional in plan['optional']
+                if optional['kind'] == 'init'
+                and optional['name'] not in optional_ready
+            }
+            init_ok, init_failures, required_init_failure = (
+                self._run_app_init_services(
+                    project_name, compose, instance_uuid,
+                    skipped_optional=skipped_optional,
+                    required_init_services=plan[
+                        'required_init_services']))
+            optional_failures.update(init_failures)
+            for service_name, output in init_failures.items():
+                context = optional_contexts[service_name]
+                self._write_failed_sig_path(
+                    context['path'], context['signature'],
+                    'docker compose init failed', phase='init',
+                    services=context['services'])
+            for optional in plan['optional']:
+                service_name = optional['name']
+                if (optional['kind'] == 'init'
+                        and service_name in optional_ready
+                        and service_name not in init_failures):
+                    self._clear_failed_sig_path(
+                        optional_contexts[service_name]['path'])
+            if not init_ok:
+                _service_name, output = required_init_failure
+                reason = 'docker compose init failed'
+                self._write_failed_sig_path(
+                    required_context['path'],
+                    required_context['signature'], reason, phase='init',
+                    services=required_context['services'])
+                self._publish_health_status(
+                    instance_uuid, 'failed',
+                    message=self._bounded_output_tail(output, reason))
+                return False, sorted(optional_failures)
+
+            unavailable_init = skipped_optional | set(init_failures)
+            for optional in plan['optional']:
+                if optional['kind'] != 'runtime':
+                    continue
+                service_name = optional['name']
+                failed_dependencies = sorted(
+                    optional['init_dependencies'] & unavailable_init)
+                if not failed_dependencies:
+                    continue
+                reason = 'optional init dependency failed'
+                optional_failures[service_name] = reason
+                optional_ready.discard(service_name)
+                context = optional_contexts[service_name]
+                self._write_failed_sig_path(
+                    context['path'], context['signature'], reason,
+                    phase='init', services=context['services'])
+
+            runtime = plan['runtime']
+            runtime_path = self._write_project_compose(
+                project_name, runtime)
+            ok, output, reason = self._start_project_services(
+                runtime_path, project_name, plan['required_runtime'],
+                remove_orphans=True,
+                max_retries=self.COMPOSE_PULL_MAX_ATTEMPTS)
+            if not ok:
+                self._write_failed_sig_path(
+                    required_context['path'],
+                    required_context['signature'], reason, phase='start',
+                    services=required_context['services'])
+                self._publish_health_status(
+                    instance_uuid, 'failed',
+                    message=self._bounded_output_tail(output, reason))
+                return False, sorted(optional_failures)
+            self._clear_failed_sig_path(required_context['path'])
+
+            for optional in plan['optional']:
+                if optional['kind'] != 'runtime':
+                    continue
+                service_name = optional['name']
+                if service_name not in optional_ready:
+                    continue
+                ok, output, reason = self._start_project_services(
+                    runtime_path, project_name, [service_name],
+                    remove_orphans=False, max_retries=1)
+                context = optional_contexts[service_name]
+                if ok:
+                    for dependency_name in optional['services']:
+                        dependency_context = optional_contexts.get(
+                            dependency_name)
+                        if dependency_context is not None:
+                            self._clear_failed_sig_path(
+                                dependency_context['path'])
+                            optional_failures.pop(dependency_name, None)
+                else:
+                    optional_failures[service_name] = output or reason
+                    self._write_failed_sig_path(
+                        context['path'], context['signature'], reason,
+                        phase='start', services=context['services'])
+
+            message = None
+            if optional_failures:
+                message = 'optional services failed: ' + ', '.join(
+                    sorted(optional_failures))
+            image = ((runtime.get('services') or {}).get(
+                prepared['primary_service']) or {}).get('image')
+            prepared['_running_health'] = {
+                'message': message,
+                'image': image,
+            }
+            if publish_running:
+                self._publish_health_status(
+                    instance_uuid, 'running', message=message, image=image)
+            return True, sorted(optional_failures)
 
     def _apply_app_project_compose(
-            self, project_name, compose, instance_uuid, primary_service):
+            self, project_name, compose, instance_uuid, primary_service,
+            force_retry=False, prepared=None):
         with self._project_lock(project_name):
-            init_ok, optional_failures = self._run_app_init_services(
-                project_name, compose, instance_uuid)
-            if not init_ok:
-                return False, optional_failures
+            prepared = prepared or self._prepare_app_project_compose(
+                project_name, compose, instance_uuid, primary_service,
+                force_retry=force_retry)
+            if not prepared.get('ok'):
+                return False, []
+            return self._start_prepared_app_project(prepared)
 
-            runtime = self._runtime_app_compose(compose)
-            required = []
-            optional = []
-            for service_name, service in (
-                    runtime.get('services') or {}).items():
-                if self._service_is_optional(service):
-                    optional.append(service_name)
-                else:
-                    required.append(service_name)
-            if primary_service not in required:
-                return False, optional_failures
-
-            ok = self._apply_project_compose(
-                project_name, runtime, instance_uuid=instance_uuid,
-                primary_service=primary_service, services=required)
+    def _prepare_system_project_compose(
+            self, project_name, compose, migration=False):
+        """Pull a system project without starting or stopping containers."""
+        with self._project_lock(project_name):
+            compose_path = self._write_project_compose(project_name, compose)
+            context = self._failure_marker_context(
+                project_name, compose, services=None)
+            failed_record = self._matching_failed_record(context)
+            if (failed_record
+                    and not (migration and failed_record.get('phase')
+                             in ('legacy', 'start'))):
+                return {
+                    'ok': False,
+                    'failed_record': failed_record,
+                }
+            deadline = time.monotonic() + self.COMPOSE_PULL_BUDGET_SECONDS
+            ok, output, reason = self._pull_project_images(
+                compose_path, project_name, None, deadline,
+                max_retries=self.COMPOSE_PULL_MAX_ATTEMPTS)
             if not ok:
-                return False, optional_failures
+                self._write_failed_sig_path(
+                    context['path'], context['signature'], reason,
+                    phase='pull', services=context['services'])
+                return {
+                    'ok': False,
+                    'output': output,
+                    'reason': reason,
+                }
+            return {
+                'ok': True,
+                'project_name': project_name,
+                'compose': compose,
+                'compose_path': compose_path,
+                'services': None,
+                'context': context,
+            }
 
-            for service_name in optional:
-                if not self._apply_project_compose(
-                        project_name, runtime, instance_uuid=None,
-                        primary_service=primary_service,
-                        services=[service_name], remove_orphans=False,
-                        failure_suffix=f'optional-{service_name}',
-                        max_retries=1):
-                    optional_failures.append(service_name)
-            if optional_failures:
-                self._publish_health_status(
-                    instance_uuid, 'running',
-                    message='optional services failed: '
-                    + ', '.join(sorted(optional_failures)),
-                    image=((runtime.get('services') or {}).get(
-                        primary_service) or {}).get('image'))
-            return True, optional_failures
+    def _start_prepared_system_project(
+            self, prepared, before_start=None):
+        project_name = prepared['project_name']
+        context = prepared['context']
+        with self._project_lock(project_name):
+            if before_start is not None and not before_start():
+                reason = 'docker compose start handoff failed'
+                self._write_failed_sig_path(
+                    context['path'], context['signature'], reason,
+                    phase='start', services=context['services'])
+                return False
+            ok, output, reason = self._start_project_services(
+                prepared['compose_path'], project_name,
+                prepared['services'], remove_orphans=True,
+                max_retries=self.COMPOSE_PULL_MAX_ATTEMPTS)
+            if ok:
+                self._clear_failed_sig_path(context['path'])
+                return True
+            self._write_failed_sig_path(
+                context['path'], context['signature'], reason,
+                phase='start', services=context['services'])
+            log('reconciler',
+                f'{project_name}: '
+                f'{self._bounded_output_tail(output, reason)}')
+            return False
 
     def _apply_project_compose(
             self, project_name, compose, instance_uuid=None,
@@ -1274,70 +2109,347 @@ class DataPlane:
         lock = self._project_lock(project_name)
         with lock:
             compose_path = self._write_project_compose(project_name, compose)
-            sig = self._compose_sig(compose)
-            if services:
-                sig = self._compose_sig({
-                    'compose': compose,
-                    'services': list(services),
-                })
-            failed_name = '.failed-compose-sig'
-            if failure_suffix:
-                failed_name += f'.{failure_suffix}'
-            failed_path = os.path.join(
-                os.path.dirname(compose_path), failed_name)
-            failed_sig, failed_reason = self._read_failed_sig_path(failed_path)
-            if failed_sig == sig:
+            selected_services = (
+                None if services is None else sorted(set(services)))
+            context = self._failure_marker_context(
+                project_name, compose,
+                services if services is not None else None,
+                failure_suffix=failure_suffix)
+            failed_record = self._matching_failed_record(context)
+            if failed_record:
                 if instance_uuid:
                     self._publish_health_status(
-                        instance_uuid, 'failed', message=failed_reason)
+                        instance_uuid, 'failed',
+                        message=failed_record.get('reason') or '')
                 return False
             if instance_uuid:
                 self._publish_health_status(instance_uuid, 'starting')
+            pull_deadline = (
+                time.monotonic() + self.COMPOSE_PULL_BUDGET_SECONDS)
+            ok, output, reason = self._pull_project_images(
+                compose_path, project_name, selected_services,
+                pull_deadline, max_retries=max_retries)
+            if not ok:
+                self._write_failed_sig_path(
+                    context['path'], context['signature'], reason,
+                    phase='pull', services=context['services'])
+                if instance_uuid:
+                    self._publish_health_status(
+                        instance_uuid, 'failed',
+                        message=self._bounded_output_tail(output, reason))
+                return False
 
-            last_output = ''
-            reason = 'docker compose up failed'
-            for attempt in range(1, max_retries + 1):
-                args = ['up', '-d', '--pull', 'missing']
-                if remove_orphans:
-                    args.append('--remove-orphans')
-                if services:
-                    args.extend(services)
-                ok, output = self._run_compose_command(
-                    compose_path, project_name,
-                    args, timeout=180)
-                if ok:
-                    self._clear_failed_sig_path(failed_path)
-                    if instance_uuid:
-                        image = ((compose.get('services') or {}).get(
-                            primary_service) or {}).get('image')
-                        self._publish_health_status(
-                            instance_uuid, 'running', image=image)
-                    return True
-                last_output = output
-                classification = self._classify_compose_failure(output)
-                reason = self._failure_reason(classification, output)
-                if classification == 'image_missing':
-                    break
-                if attempt < max_retries:
-                    time.sleep(min(10 * (2 ** (attempt - 1)), 60))
+            ok, output, reason = self._start_project_services(
+                compose_path, project_name, selected_services,
+                remove_orphans=remove_orphans, max_retries=max_retries)
+            if ok:
+                self._clear_failed_sig_path(context['path'])
+                if instance_uuid:
+                    image = ((compose.get('services') or {}).get(
+                        primary_service) or {}).get('image')
+                    self._publish_health_status(
+                        instance_uuid, 'running', image=image)
+                return True
 
-            self._write_failed_sig_path(failed_path, sig, reason)
+            self._write_failed_sig_path(
+                context['path'], context['signature'], reason,
+                phase='start', services=context['services'])
             if instance_uuid:
-                tail = '\n'.join(last_output.splitlines()[-5:]) or reason
                 self._publish_health_status(
-                    instance_uuid, 'failed', message=tail)
+                    instance_uuid, 'failed',
+                    message=self._bounded_output_tail(output, reason))
             return False
 
+    def _pull_project_images(
+            self, compose_path, project_name, services, deadline,
+            max_retries=5):
+        pull_all = services is None
+        services = sorted(set(services or ()))
+        if not pull_all and not services:
+            return True, '', ''
+        last_output = ''
+        reason = 'docker compose pull failed'
+        for attempt in range(1, max_retries + 1):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                last_output = self._bounded_output_tail(
+                    last_output, 'docker compose pull timed out')
+                return False, last_output, 'docker compose pull timed out'
+            service_summary = ','.join(services) if services else 'all'
+            log('reconciler',
+                f'{project_name}: docker compose pull '
+                f'(attempt {attempt}/{max_retries}, '
+                f'services={service_summary})')
+            ok, output = self._run_compose_command_streaming(
+                compose_path, project_name,
+                ['pull', '--policy', 'missing', *services],
+                timeout=remaining)
+            if ok:
+                return True, output, ''
+            last_output = output
+            classification = self._classify_compose_failure(output)
+            reason = self._failure_reason(
+                classification, output, phase='pull')
+            if classification in (
+                    'image_missing', 'no_space', 'storage_corruption'):
+                break
+            if attempt >= max_retries:
+                break
+            delay = min(10 * (2 ** (attempt - 1)), 60)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                reason = 'docker compose pull timed out'
+                break
+            time.sleep(min(delay, remaining))
+        return False, last_output, reason
+
+    def _start_project_services(
+            self, compose_path, project_name, services,
+            remove_orphans=True, max_retries=5):
+        services = sorted(set(services or ()))
+        last_output = ''
+        reason = 'docker compose up failed'
+        deadline = time.monotonic() + self.COMPOSE_START_TIMEOUT_SECONDS
+        for attempt in range(1, max_retries + 1):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False, last_output, 'docker compose up timed out'
+            args = ['up', '-d', '--pull', 'never']
+            if remove_orphans:
+                args.append('--remove-orphans')
+            args.extend(services)
+            ok, output = self._run_compose_command(
+                compose_path, project_name, args,
+                timeout=remaining)
+            if ok:
+                return True, output, ''
+            last_output = output
+            classification = self._classify_compose_failure(output)
+            reason = self._failure_reason(classification, output)
+            if classification in (
+                    'image_missing', 'no_space', 'storage_corruption'):
+                break
+            if attempt < max_retries:
+                delay = min(10 * (2 ** (attempt - 1)), 60)
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    reason = 'docker compose up timed out'
+                    break
+                time.sleep(min(delay, remaining))
+        return False, last_output, reason
+
     def _write_project_compose(self, project_name, compose):
-        compose_path = self._project_compose_path(project_name)
-        os.makedirs(os.path.dirname(compose_path), exist_ok=True)
-        tmp_path = compose_path + '.tmp'
-        with open(tmp_path, 'w') as stream:
-            json.dump(compose, stream, indent=2)
-            stream.flush()
-            os.fsync(stream.fileno())
-        os.replace(tmp_path, compose_path)
-        return compose_path
+        with self._project_lock(project_name):
+            compose_path = self._project_compose_path(project_name)
+            os.makedirs(os.path.dirname(compose_path), exist_ok=True)
+            tmp_path = compose_path + '.tmp'
+            with open(tmp_path, 'w') as stream:
+                json.dump(compose, stream, indent=2)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(tmp_path, compose_path)
+            return compose_path
+
+    def _run_compose_command_streaming(
+            self, compose_path, project_name, args, timeout):
+        """Run a long Compose command with bounded, redacted diagnostics."""
+        command = [
+            'docker', 'compose', '-f', compose_path, '-p', project_name,
+            *args,
+        ]
+        tail = deque(maxlen=self.COMPOSE_OUTPUT_TAIL_LINES)
+        classification_signals = {}
+        proc = None
+        selector = None
+        partial = ''
+        discarding_line = False
+        classification_scan_tail = ''
+        decoder = codecs.getincrementaldecoder('utf-8')(errors='replace')
+
+        canonical_signals = {
+            'no_space': 'no space left on device',
+            'image_missing': 'manifest unknown',
+            'storage_corruption': 'failed to register layer',
+        }
+
+        def scan_failure_signals(decoded):
+            nonlocal classification_scan_tail
+            scan = classification_scan_tail + decoded
+            classification = self._classify_compose_failure(scan)
+            if classification != 'transient':
+                classification_signals.setdefault(
+                    classification, canonical_signals[classification])
+            classification_scan_tail = scan[-128:]
+
+        def line_boundary(value):
+            newline = value.find('\n')
+            carriage_return = value.find('\r')
+            candidates = [
+                position for position in (newline, carriage_return)
+                if position >= 0
+            ]
+            return min(candidates) if candidates else -1
+
+        def remember(line):
+            safe = shared.redact_log_message(line.rstrip('\r\n'))
+            if len(safe) > self.COMPOSE_OUTPUT_LINE_CHARS:
+                safe = safe[:self.COMPOSE_OUTPUT_LINE_CHARS] + ' [truncated]'
+            if safe:
+                classification = self._classify_compose_failure(safe)
+                if classification != 'transient':
+                    classification_signals.setdefault(classification, safe)
+                log('compose', safe)
+                tail.append(safe)
+
+        def rendered_output():
+            tail_lines = list(tail)
+            signals = [
+                line for line in classification_signals.values()
+                if line not in tail_lines
+            ]
+            return '\n'.join(signals + tail_lines)
+
+        def consume(chunk, final=False):
+            nonlocal discarding_line, partial
+            decoded = decoder.decode(chunk, final=final)
+            scan_failure_signals(decoded)
+            truncation_marker = ' [truncated]'
+            retained_chars = max(
+                1, self.COMPOSE_OUTPUT_LINE_CHARS
+                - len(truncation_marker))
+            while decoded:
+                if discarding_line:
+                    newline = line_boundary(decoded)
+                    if newline < 0:
+                        decoded = ''
+                        break
+                    remember(partial + truncation_marker)
+                    partial = ''
+                    discarding_line = False
+                    decoded = decoded[newline + 1:]
+                    continue
+
+                newline = line_boundary(decoded)
+                segment = decoded if newline < 0 else decoded[:newline]
+                available = retained_chars - len(partial)
+                if len(segment) > available:
+                    partial += segment[:available]
+                    if newline < 0:
+                        discarding_line = True
+                        decoded = ''
+                        break
+                    remember(partial + truncation_marker)
+                    partial = ''
+                    decoded = decoded[newline + 1:]
+                    continue
+
+                partial += segment
+                if newline < 0:
+                    decoded = ''
+                    break
+                remember(partial)
+                partial = ''
+                decoded = decoded[newline + 1:]
+
+            if final:
+                if discarding_line:
+                    remember(partial + truncation_marker)
+                elif partial:
+                    remember(partial)
+                partial = ''
+                discarding_line = False
+
+        try:
+            proc = subprocess.Popen(
+                command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                bufsize=0, start_new_session=True)
+            output_fd = proc.stdout.fileno()
+            os.set_blocking(output_fd, False)
+            selector = selectors.DefaultSelector()
+            selector.register(output_fd, selectors.EVENT_READ)
+            deadline = time.monotonic() + timeout
+            timed_out = False
+            reached_eof = False
+            while not reached_eof:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    timed_out = True
+                    break
+                events = selector.select(timeout=min(0.25, remaining))
+                if not events:
+                    continue
+                try:
+                    chunk = os.read(output_fd, 4096)
+                except BlockingIOError:
+                    continue
+                if not chunk:
+                    reached_eof = True
+                    break
+                consume(chunk)
+
+            if timed_out:
+                self._terminate_compose_process(proc)
+                while True:
+                    try:
+                        chunk = os.read(output_fd, 4096)
+                    except BlockingIOError:
+                        break
+                    if not chunk:
+                        break
+                    consume(chunk)
+                consume(b'', final=True)
+                tail.append(
+                    f'docker compose {args[0]} timed out after '
+                    f'{max(1, int(timeout))} seconds')
+                return False, rendered_output()
+
+            consume(b'', final=True)
+            remaining = max(0.1, deadline - time.monotonic())
+            try:
+                returncode = proc.wait(timeout=remaining)
+            except subprocess.TimeoutExpired:
+                self._terminate_compose_process(proc)
+                tail.append(
+                    f'docker compose {args[0]} timed out after '
+                    f'{max(1, int(timeout))} seconds')
+                return False, rendered_output()
+            return returncode == 0, rendered_output()
+        except OSError as exception:
+            if proc is not None:
+                self._terminate_compose_process(proc)
+            return False, (
+                f'docker compose error: {type(exception).__name__}')
+        finally:
+            if selector is not None:
+                selector.close()
+            if proc is not None and proc.stdout is not None:
+                proc.stdout.close()
+
+    @staticmethod
+    def _terminate_compose_process(proc):
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+        except (OSError, ProcessLookupError):
+            try:
+                proc.terminate()
+            except (OSError, ProcessLookupError):
+                pass
+        try:
+            proc.wait(timeout=5)
+            return
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except (OSError, ProcessLookupError):
+            try:
+                proc.kill()
+            except (OSError, ProcessLookupError):
+                pass
+        try:
+            proc.wait(timeout=5)
+        except (OSError, subprocess.TimeoutExpired):
+            pass
 
     @staticmethod
     def _run_compose_command(compose_path, project_name, args, timeout):
@@ -1369,9 +2481,15 @@ class DataPlane:
 
     def _commit_v2_migration(self):
         if os.path.exists(self.COMPOSE_PATH):
-            self._run_compose_command(
+            ok, output = self._run_compose_command(
                 self.COMPOSE_PATH, 'state', ['down', '--remove-orphans'],
                 timeout=300)
+            if not ok:
+                reason = self._failure_reason(
+                    self._classify_compose_failure(output), output)
+                log('reconciler',
+                    f'Apps-v2 migration commit failed: {reason}')
+                return False
         state_dir = os.path.dirname(self.DESIRED_STATE_V2_PATH)
         marker = os.path.join(state_dir, 'apps-v2-migrated')
         marker_tmp = marker + '.tmp'
@@ -1386,6 +2504,7 @@ class DataPlane:
             except FileNotFoundError:
                 pass
         log('reconciler', 'Apps-v2 migration committed')
+        return True
 
     def _remove_absent_v2_projects(self, desired_projects):
         if not os.path.isdir(self.PROJECTS_DIR):
@@ -1394,30 +2513,80 @@ class DataPlane:
             if (not entry.is_dir() or entry.name == 'reefy-system'
                     or entry.name in desired_projects):
                 continue
-            compose_path = os.path.join(entry.path, 'compose.json')
-            if os.path.exists(compose_path):
-                self._run_compose_command(
-                    compose_path, entry.name,
-                    ['down', '--remove-orphans'], timeout=300)
-            shutil.rmtree(entry.path, ignore_errors=True)
+            with self._project_lock(entry.name):
+                compose_path = os.path.join(entry.path, 'compose.json')
+                if os.path.exists(compose_path):
+                    self._run_compose_command(
+                        compose_path, entry.name,
+                        ['down', '--remove-orphans'], timeout=300)
+                shutil.rmtree(entry.path, ignore_errors=True)
+
+    @staticmethod
+    def _read_failed_sig_record(path):
+        try:
+            with open(path) as stream:
+                content = stream.read()
+        except OSError:
+            return {}
+        try:
+            record = json.loads(content)
+        except (TypeError, ValueError):
+            signature, _, reason = content.partition('\n')
+            signature = signature.strip()
+            if not signature:
+                return {}
+            return {
+                'version': 1,
+                'signature': signature,
+                'services': [],
+                'phase': 'legacy',
+                'reason': reason.strip(),
+            }
+        if not isinstance(record, dict) or not record.get('signature'):
+            return {}
+        services = record.get('services')
+        if not isinstance(services, list):
+            services = []
+        return {
+            'version': record.get('version') or 2,
+            'signature': str(record['signature']),
+            'services': sorted(
+                str(service) for service in services),
+            'phase': record.get('phase') or 'legacy',
+            'reason': str(record.get('reason') or ''),
+        }
 
     @staticmethod
     def _read_failed_sig_path(path):
-        try:
-            with open(path) as stream:
-                signature, _, reason = stream.read().partition('\n')
-            return signature.strip() or None, reason.strip()
-        except OSError:
-            return None, ''
+        record = DataPlane._read_failed_sig_record(path)
+        return record.get('signature'), record.get('reason', '')
 
     @staticmethod
-    def _write_failed_sig_path(path, signature, reason):
+    def _write_failed_sig_path(
+            path, signature, reason, phase='start', services=None):
+        temporary = path + '.tmp'
         try:
-            with open(path, 'w') as stream:
-                stream.write(f'{signature}\n{reason}')
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            record = {
+                'version': 2,
+                'signature': signature,
+                'services': sorted(set(services or ())),
+                'phase': phase,
+                'reason': shared.redact_log_message(reason)[:500],
+            }
+            with open(temporary, 'w') as stream:
+                json.dump(record, stream, sort_keys=True)
+                stream.write('\n')
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary, path)
         except OSError as exception:
             log('reconciler',
                 f'cannot persist project failure ({type(exception).__name__})')
+            try:
+                os.remove(temporary)
+            except OSError:
+                pass
 
     @staticmethod
     def _clear_failed_sig_path(path):
@@ -1644,6 +2813,8 @@ class DataPlane:
             return False
         state = self._read_json(self._active_state_path())
         if not self._is_v2_state(state):
+            return False
+        if self._v2_migration_pending():
             return False
         app = next((candidate for candidate in state.get('apps') or []
                     if (candidate.get('project_name') == project
@@ -2586,7 +3757,7 @@ Environment=MQTT_PORT={self.port}
 
     @staticmethod
     def _classify_compose_failure(output):
-        """Bucket `docker compose up` output into a retry policy class.
+        """Bucket Docker Compose output into a retry policy class.
 
         Order matters: `no_space` is checked FIRST because the kernel's
         "no space left on device" often rides on a "failed to register
@@ -2598,9 +3769,12 @@ Environment=MQTT_PORT={self.port}
         image_missing = [
             'manifest unknown',
             'not found: manifest',
+            'no such image',
             'pull access denied',
             'repository does not exist',
             'requested access to the resource is denied',
+            'denied: requested access',
+            'unauthorized: authentication required',
             'manifest for ',                # "...not found: manifest unknown"
         ]
         if any(s in o for s in image_missing):
@@ -2616,12 +3790,12 @@ Environment=MQTT_PORT={self.port}
         return 'transient'                 # network/5xx/timeout -> keep retrying
 
     @staticmethod
-    def _failure_reason(cls, output):
+    def _failure_reason(cls, output, phase='up'):
         return {
             'no_space': 'out of disk space',
             'image_missing': 'image not found or access denied',
             'storage_corruption': 'docker storage error',
-        }.get(cls, 'docker compose up failed')
+        }.get(cls, f'docker compose {phase} failed')
 
     def _prune_docker(self, volumes=False):
         """Reclaim docker space; `volumes=True` also drops anonymous
@@ -2633,7 +3807,8 @@ Environment=MQTT_PORT={self.port}
             cmd.append('--volumes')
         reclaimed_any = False
         try:
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=120)
             for line in (result.stdout or '').strip().split('\n'):
                 if line.strip():
                     log('mqtt', f'prune: {line}')

--- a/board/reefy/reefy/tests/test_dataplane.py
+++ b/board/reefy/reefy/tests/test_dataplane.py
@@ -5,6 +5,7 @@ non-fatally) and the data-side behavior of the split methods."""
 
 import json
 import os
+import sys
 import tempfile
 import threading
 import types
@@ -128,10 +129,10 @@ class AppsV2Tests(unittest.TestCase):
         barrier = threading.Barrier(2)
         entered = []
 
-        def apply_app(name, compose, instance_uuid, primary_service):
-            entered.append(name)
+        def reconcile(app, migration, restore_failed, prepared=None):
+            entered.append(app['project_name'])
             barrier.wait(timeout=2)
-            return True, []
+            return True, ('', [])
 
         with mock.patch.object(
                 self.dp, '_v2_migration_pending', return_value=False), \
@@ -139,11 +140,10 @@ class AppsV2Tests(unittest.TestCase):
                     self.dp, '_apply_project_compose',
                     return_value=True), \
                 mock.patch.object(
-                    self.dp, '_apply_app_project_compose',
-                    side_effect=apply_app), \
+                    self.dp, '_reconcile_v2_app',
+                    side_effect=reconcile), \
                 mock.patch.object(self.dp, '_remove_absent_v2_projects'), \
-                mock.patch.object(
-                    self.dp, '_prepare_app_artifacts', return_value=True):
+                mock.patch.object(self.dp, '_prepare_app_artifacts'):
             warnings = self.dp._apply_v2_projects(self._state())
 
         self.assertEqual(warnings, [])
@@ -152,9 +152,11 @@ class AppsV2Tests(unittest.TestCase):
     def test_one_app_failure_does_not_block_another(self):
         calls = []
 
-        def apply_app(name, compose, instance_uuid, primary_service):
-            calls.append(name)
-            return instance_uuid != 'app-a', []
+        def reconcile(app, migration, restore_failed, prepared=None):
+            calls.append(app['project_name'])
+            if app['instance_uuid'] == 'app-a':
+                return False, ('app_project_failed', [])
+            return True, ('', [])
 
         with mock.patch.object(
                 self.dp, '_v2_migration_pending', return_value=False), \
@@ -162,11 +164,10 @@ class AppsV2Tests(unittest.TestCase):
                     self.dp, '_apply_project_compose',
                     return_value=True), \
                 mock.patch.object(
-                    self.dp, '_apply_app_project_compose',
-                    side_effect=apply_app), \
+                    self.dp, '_reconcile_v2_app',
+                    side_effect=reconcile), \
                 mock.patch.object(self.dp, '_remove_absent_v2_projects'), \
-                mock.patch.object(
-                    self.dp, '_prepare_app_artifacts', return_value=True):
+                mock.patch.object(self.dp, '_prepare_app_artifacts'):
             warnings = self.dp._apply_v2_projects(self._state())
 
         self.assertIn('reefy-app-b', calls)
@@ -239,11 +240,10 @@ class AppsV2Tests(unittest.TestCase):
                     self.dp, '_apply_project_compose',
                     side_effect=apply_project), \
                 mock.patch.object(
-                    self.dp, '_apply_app_project_compose',
-                    return_value=(True, [])) as apply_app, \
+                    self.dp, '_reconcile_v2_app',
+                    return_value=(True, ('', []))) as apply_app, \
                 mock.patch.object(self.dp, '_remove_absent_v2_projects'), \
-                mock.patch.object(
-                    self.dp, '_prepare_app_artifacts', return_value=True):
+                mock.patch.object(self.dp, '_prepare_app_artifacts'):
             warnings = self.dp._apply_v2_projects(self._state())
 
         self.assertEqual(calls, ['reefy-system'])
@@ -260,15 +260,29 @@ class AppsV2Tests(unittest.TestCase):
             order.append(f'{project}:{args[0]}')
             return True, ''
 
-        def apply_system(*_args, **_kwargs):
+        def prepare_system(*_args, **_kwargs):
+            order.append('reefy-system:pull')
+            return {'ok': True}
+
+        def prepare_app(app, _restore_failed):
+            order.append(f'{app["project_name"]}:pull')
+            return True, '', {'ok': True}
+
+        def start_system(_prepared, before_start=None):
+            self.assertTrue(before_start())
             order.append('reefy-system:up')
             return True
 
         with mock.patch.object(
                 self.dp, '_run_compose_command', side_effect=run), \
                 mock.patch.object(
-                    self.dp, '_apply_project_compose',
-                    side_effect=apply_system), \
+                    self.dp, '_prepare_system_project_compose',
+                    side_effect=prepare_system), \
+                mock.patch.object(
+                    self.dp, '_prepare_v2_app', side_effect=prepare_app), \
+                mock.patch.object(
+                    self.dp, '_start_prepared_system_project',
+                    side_effect=start_system), \
                 mock.patch.object(
                     self.dp, '_reconcile_v2_app',
                     return_value=(True, ('', []))), \
@@ -277,12 +291,14 @@ class AppsV2Tests(unittest.TestCase):
             warnings = self.dp._apply_v2_projects(self._state())
 
         self.assertEqual(warnings, [])
-        self.assertEqual(order[:4], [
-            'reefy-system:rm',
-            'state:stop',
-            'state:rm',
-            'reefy-system:up',
-        ])
+        first_legacy_mutation = min(
+            index for index, value in enumerate(order)
+            if value in ('reefy-system:rm', 'state:stop', 'state:rm'))
+        for project in ('reefy-system', 'reefy-app-a', 'reefy-app-b'):
+            self.assertLess(order.index(f'{project}:pull'),
+                            first_legacy_mutation)
+        self.assertLess(order.index('state:rm'),
+                        order.index('reefy-system:up'))
         self.assertEqual(commands[1][2], [
             'stop', 'reefy-llm-proxy', 'reefy-app-api'])
         self.assertEqual(commands[2][2], [
@@ -297,10 +313,21 @@ class AppsV2Tests(unittest.TestCase):
             commands.append((path, project, args, timeout))
             return True, ''
 
+        def fail_start(_prepared, before_start=None):
+            self.assertTrue(before_start())
+            return False
+
         with mock.patch.object(
                 self.dp, '_run_compose_command', side_effect=run), \
                 mock.patch.object(
-                    self.dp, '_apply_project_compose', return_value=False), \
+                    self.dp, '_prepare_system_project_compose',
+                    return_value={'ok': True}), \
+                mock.patch.object(
+                    self.dp, '_prepare_v2_app',
+                    return_value=(True, '', {'ok': True})), \
+                mock.patch.object(
+                    self.dp, '_start_prepared_system_project',
+                    side_effect=fail_start), \
                 mock.patch.object(
                     self.dp, '_reconcile_v2_app') as apply_app, \
                 mock.patch.object(self.dp, '_remove_absent_v2_projects'), \
@@ -331,15 +358,26 @@ class AppsV2Tests(unittest.TestCase):
             commands.append((path, project, args, timeout))
             return True, ''
 
-        def reconcile(app, migration, restore_failed):
+        def reconcile(app, migration, restore_failed, prepared=None):
             if app['instance_uuid'] == 'app-b':
                 return False, ('app_project_failed', [])
             return True, ('', [])
 
+        def start_system(_prepared, before_start=None):
+            self.assertTrue(before_start())
+            return True
+
         with mock.patch.object(
                 self.dp, '_run_compose_command', side_effect=run), \
                 mock.patch.object(
-                    self.dp, '_apply_project_compose', return_value=True), \
+                    self.dp, '_prepare_system_project_compose',
+                    return_value={'ok': True}), \
+                mock.patch.object(
+                    self.dp, '_prepare_v2_app',
+                    return_value=(True, '', {'ok': True})), \
+                mock.patch.object(
+                    self.dp, '_start_prepared_system_project',
+                    side_effect=start_system), \
                 mock.patch.object(
                     self.dp, '_reconcile_v2_app', side_effect=reconcile), \
                 mock.patch.object(self.dp, '_remove_absent_v2_projects'), \
@@ -360,6 +398,299 @@ class AppsV2Tests(unittest.TestCase):
             (self.dp.COMPOSE_PATH, 'state',
              ['up', '-d', '--pull', 'missing'], 300),
             commands)
+
+    def test_migration_commit_down_failure_keeps_legacy_source(self):
+        self._seed_legacy_state()
+        with mock.patch.object(
+                self.dp, '_run_compose_command',
+                return_value=(False, 'synthetic down failure')):
+            self.assertFalse(self.dp._commit_v2_migration())
+
+        self.assertTrue(os.path.exists(self.dp.DESIRED_STATE_PATH))
+        self.assertTrue(os.path.exists(self.dp.COMPOSE_PATH))
+        self.assertFalse((Path(self.tempdir) / 'apps-v2-migrated').exists())
+
+    def test_commit_failure_rolls_back_and_reports_system_warning(self):
+        legacy = self._seed_legacy_state()
+        state = self._state()
+        health_calls = []
+
+        def prepare_app(app, _restore_failed):
+            return True, '', {
+                'ok': True,
+                'project_name': app['project_name'],
+            }
+
+        with mock.patch.object(
+                self.dp, '_prepare_system_project_compose',
+                return_value={'ok': True}), \
+                mock.patch.object(
+                    self.dp, '_prepare_v2_app', side_effect=prepare_app), \
+                mock.patch.object(
+                    self.dp, '_start_prepared_system_project',
+                    side_effect=lambda _prepared, before_start=None:
+                    before_start()), \
+                mock.patch.object(
+                    self.dp, '_prepare_v2_system_handoff',
+                    return_value=True), \
+                mock.patch.object(
+                    self.dp, '_reconcile_v2_app',
+                    return_value=(True, ('', []))), \
+                mock.patch.object(self.dp, '_remove_absent_v2_projects'), \
+                mock.patch.object(
+                    self.dp, '_commit_v2_migration', return_value=False), \
+                mock.patch.object(
+                    self.dp, '_rollback_v2_migration', return_value=True), \
+                mock.patch.object(
+                    self.dp, '_publish_health_status',
+                    side_effect=lambda *args, **kwargs:
+                    health_calls.append((args, kwargs))):
+            warnings = self.dp._apply_v2_projects(state)
+
+        self.assertIn({
+            'code': 'system_project_failed',
+            'instance_uuid': '',
+            'volume': '',
+        }, warnings)
+        running = {
+            args[0]: kwargs.get('image')
+            for args, kwargs in health_calls
+            if args[1] == 'running'
+        }
+        self.assertEqual(
+            len([args for args, _kwargs in health_calls
+                 if args[1] == 'running']),
+            2)
+        self.assertEqual(running, {
+            'app-a': legacy['services']['app-a']['image'],
+            'app-b': legacy['services']['app-b']['image'],
+        })
+
+    def test_migration_preflight_abort_resets_only_prepared_bystander(self):
+        legacy = self._seed_legacy_state()
+        state = self._state()
+        events = []
+
+        def prepare_app(app, _restore_failed):
+            self.dp._publish_health_status(
+                app['instance_uuid'], 'starting')
+            if app['instance_uuid'] == 'app-b':
+                self.dp._publish_health_status(
+                    app['instance_uuid'], 'failed',
+                    message='synthetic preflight failure')
+                return False, 'app_project_failed', None
+            return True, '', {
+                'ok': True,
+                'project_name': app['project_name'],
+            }
+
+        with mock.patch.object(
+                self.dp, '_prepare_system_project_compose',
+                return_value={'ok': True}), \
+                mock.patch.object(
+                    self.dp, '_prepare_v2_app', side_effect=prepare_app), \
+                mock.patch.object(
+                    self.dp, '_publish_health_status',
+                    side_effect=lambda *args, **kwargs:
+                    events.append((args, kwargs))), \
+                mock.patch.object(
+                    self.dp, '_start_prepared_system_project') as start:
+            warnings = self.dp._apply_v2_projects(state)
+
+        start.assert_not_called()
+        self.assertEqual(
+            [args[1] for args, _kwargs in events if args[0] == 'app-a'],
+            ['starting', 'running'])
+        self.assertEqual(
+            [args[1] for args, _kwargs in events if args[0] == 'app-b'],
+            ['starting', 'failed'])
+        app_a_running = next(
+            kwargs for args, kwargs in events
+            if args[:2] == ('app-a', 'running'))
+        self.assertEqual(
+            app_a_running['image'], legacy['services']['app-a']['image'])
+        self.assertEqual(warnings[0]['instance_uuid'], 'app-b')
+
+    def test_migration_retry_intent_reaches_only_target_preflight(self):
+        self._seed_legacy_state()
+        state = self._state()
+        intent = {
+            'project_name': 'reefy-app-a',
+            'signature': 'synthetic-signature',
+        }
+
+        with mock.patch.object(
+                self.dp, '_prepare_system_project_compose',
+                return_value={'ok': True}), \
+                mock.patch.object(
+                    self.dp, '_prepare_v2_app',
+                    return_value=(False, 'app_project_failed', None)) as prepare:
+            self.dp._apply_v2_projects(state, force_retry=intent)
+
+        calls = {
+            call.args[0]['project_name']: call
+            for call in prepare.call_args_list
+        }
+        self.assertEqual(
+            calls['reefy-app-a'].kwargs['force_retry'], intent)
+        self.assertNotIn('force_retry', calls['reefy-app-b'].kwargs)
+
+    def test_migration_app_failure_rollback_resets_bystander_health(self):
+        legacy = self._seed_legacy_state()
+        state = self._state()
+        events = []
+
+        def prepare_app(app, _restore_failed):
+            self.dp._publish_health_status(app['instance_uuid'], 'starting')
+            return True, '', {
+                'ok': True,
+                'project_name': app['project_name'],
+            }
+
+        def reconcile(app, migration, restore_failed, prepared=None):
+            if app['instance_uuid'] == 'app-b':
+                self.dp._publish_health_status(
+                    'app-b', 'failed', message='synthetic start failure')
+                return False, ('app_project_failed', [])
+            return True, ('', [])
+
+        with mock.patch.object(
+                self.dp, '_prepare_system_project_compose',
+                return_value={'ok': True}), \
+                mock.patch.object(
+                    self.dp, '_prepare_v2_app', side_effect=prepare_app), \
+                mock.patch.object(
+                    self.dp, '_start_prepared_system_project',
+                    return_value=True), \
+                mock.patch.object(
+                    self.dp, '_reconcile_v2_app', side_effect=reconcile), \
+                mock.patch.object(self.dp, '_remove_absent_v2_projects'), \
+                mock.patch.object(
+                    self.dp, '_rollback_v2_migration', return_value=True), \
+                mock.patch.object(
+                    self.dp, '_publish_health_status',
+                    side_effect=lambda *args, **kwargs:
+                    events.append((args, kwargs))):
+            self.dp._apply_v2_projects(state)
+
+        app_a = [
+            (args[1], kwargs.get('image'))
+            for args, kwargs in events if args[0] == 'app-a'
+        ]
+        app_b = [
+            args[1] for args, _kwargs in events if args[0] == 'app-b'
+        ]
+        self.assertEqual(app_a, [
+            ('starting', None),
+            ('running', legacy['services']['app-a']['image']),
+        ])
+        self.assertEqual(app_b, ['starting', 'failed'])
+
+    def test_migration_success_publishes_one_committed_running_per_app(self):
+        self._seed_legacy_state()
+        state = self._state()
+        events = []
+
+        def prepare_app(app, _restore_failed):
+            self.dp._publish_health_status(app['instance_uuid'], 'starting')
+            return True, '', {
+                'ok': True,
+                'project_name': app['project_name'],
+                '_running_health': {
+                    'message': None,
+                    'image': app['compose']['services']['app']['image'],
+                },
+            }
+
+        with mock.patch.object(
+                self.dp, '_prepare_system_project_compose',
+                return_value={'ok': True}), \
+                mock.patch.object(
+                    self.dp, '_prepare_v2_app', side_effect=prepare_app), \
+                mock.patch.object(
+                    self.dp, '_start_prepared_system_project',
+                    return_value=True), \
+                mock.patch.object(
+                    self.dp, '_reconcile_v2_app',
+                    return_value=(True, ('', []))), \
+                mock.patch.object(self.dp, '_remove_absent_v2_projects'), \
+                mock.patch.object(
+                    self.dp, '_commit_v2_migration', return_value=True), \
+                mock.patch.object(
+                    self.dp, '_publish_health_status',
+                    side_effect=lambda *args, **kwargs:
+                    events.append((args, kwargs))):
+            warnings = self.dp._apply_v2_projects(state)
+
+        self.assertEqual(warnings, [])
+        for app in state['apps']:
+            instance_uuid = app['instance_uuid']
+            app_events = [
+                (args[1], kwargs.get('image'))
+                for args, kwargs in events if args[0] == instance_uuid
+            ]
+            self.assertEqual(app_events, [
+                ('starting', None),
+                ('running', app['compose']['services']['app']['image']),
+            ])
+
+    def test_legacy_app_stop_failure_is_sticky_and_terminal(self):
+        app = self._state()['apps'][0]
+        compose = app['compose']
+        context = self.dp._required_app_failure_context(
+            app['project_name'], compose, 'app')
+        prepared = {
+            'ok': True,
+            'project_name': app['project_name'],
+            'instance_uuid': app['instance_uuid'],
+            'required_context': context,
+        }
+
+        with mock.patch.object(
+                self.dp, '_run_compose_command',
+                return_value=(False, 'synthetic stop failure')), \
+                mock.patch.object(
+                    self.dp, '_start_prepared_app_project') as start, \
+                mock.patch.object(
+                    self.dp, '_publish_health_status') as health:
+            result = self.dp._reconcile_v2_app(
+                app, migration=True, restore_failed=False,
+                prepared=prepared)
+
+        self.assertEqual(result, (False, 'app_stop_failed'))
+        start.assert_not_called()
+        self.assertEqual(
+            [call.args[1] for call in health.call_args_list], ['failed'])
+        marker = self.dp._read_failed_sig_record(context['path'])
+        self.assertEqual(marker['phase'], 'start')
+
+    def test_rollback_cleanup_failure_does_not_confirm_legacy_running(self):
+        self._seed_legacy_state()
+        state = self._state()
+        for app in state['apps']:
+            self.dp._write_project_compose(
+                app['project_name'], app['compose'])
+        self.dp._write_project_compose(
+            'reefy-system', state['system_project']['compose'])
+        commands = []
+
+        def run(_path, project, args, timeout):
+            commands.append((project, args))
+            if project == 'reefy-app-a' and args == ['stop']:
+                return False, 'synthetic stop failure'
+            return True, ''
+
+        with mock.patch.object(
+                self.dp, '_run_compose_command', side_effect=run), \
+                mock.patch.object(dataplane, 'log') as logger:
+            self.assertFalse(self.dp._rollback_v2_migration(
+                state, 'reefy-system'))
+
+        self.assertIn(
+            ('state', ['up', '-d', '--pull', 'missing']), commands)
+        self.assertTrue(any(
+            'rollback cleanup failures' in str(call.args[1])
+            for call in logger.call_args_list))
 
     def test_migration_clears_sticky_system_failure_after_name_release(self):
         self._seed_legacy_state()
@@ -389,20 +720,30 @@ class AppsV2Tests(unittest.TestCase):
                 order.append('stop-legacy')
             return True, ''
 
+        def start_prepared(_prepared, publish_running=True):
+            self.assertFalse(publish_running)
+            order.append('start-v2')
+            return True, []
+
         with mock.patch.object(
                 self.dp, '_prepare_app_artifacts',
                 side_effect=lambda _app: order.append('prepare') or True), \
                 mock.patch.object(
                     self.dp, '_run_compose_command', side_effect=run), \
                 mock.patch.object(
-                    self.dp, '_apply_app_project_compose',
+                    self.dp, '_prepare_app_project_compose',
                     side_effect=lambda *_args, **_kwargs:
-                    (order.append('start-v2') or True, [])):
+                    (order.append('pull-images') or {
+                        'ok': True, 'project_name': 'reefy-app-a'})), \
+                mock.patch.object(
+                    self.dp, '_start_prepared_app_project',
+                    side_effect=start_prepared):
             result = self.dp._reconcile_v2_app(
                 app, migration=True, restore_failed=False)
 
         self.assertEqual(result, (True, ('', [])))
-        self.assertEqual(order, ['prepare', 'stop-legacy', 'start-v2'])
+        self.assertEqual(order, [
+            'prepare', 'pull-images', 'stop-legacy', 'start-v2'])
 
     def test_optional_warning_does_not_block_migration_commit(self):
         with mock.patch.object(
@@ -410,13 +751,19 @@ class AppsV2Tests(unittest.TestCase):
                 mock.patch.object(
                     self.dp, '_read_json', return_value={}), \
                 mock.patch.object(
-                    self.dp, '_apply_project_compose', return_value=True), \
+                    self.dp, '_prepare_system_project_compose',
+                    return_value={'ok': True}), \
                 mock.patch.object(
-                    self.dp, '_apply_app_project_compose',
-                    return_value=(True, ['diagnostics'])), \
+                    self.dp, '_prepare_v2_app',
+                    return_value=(True, '', {'ok': True})), \
+                mock.patch.object(
+                    self.dp, '_start_prepared_system_project',
+                    side_effect=lambda _prepared, before_start=None:
+                    before_start()), \
+                mock.patch.object(
+                    self.dp, '_reconcile_v2_app',
+                    return_value=(True, ('', ['diagnostics']))), \
                 mock.patch.object(self.dp, '_remove_absent_v2_projects'), \
-                mock.patch.object(
-                    self.dp, '_prepare_app_artifacts', return_value=True), \
                 mock.patch.object(
                     self.dp, '_run_compose_command', return_value=(True, '')), \
                 mock.patch.object(self.dp, '_commit_v2_migration') as commit:
@@ -450,6 +797,25 @@ class AppsV2Tests(unittest.TestCase):
         event['Actor']['Attributes']['exitCode'] = '0'
         event['Actor']['Attributes']['ai.reefy.lifecycle'] = 'init'
         self.assertFalse(self.dp._handle_docker_event(event))
+
+    def test_service_die_event_is_suppressed_during_pending_migration(self):
+        with open(self.dp.DESIRED_STATE_V2_PATH, 'w') as stream:
+            json.dump(self._state(), stream)
+        Path(self.dp.DESIRED_STATE_PATH).write_text('{}')
+        event = {
+            'Action': 'die',
+            'Actor': {'Attributes': {
+                'ai.reefy.lifecycle': 'service',
+                'ai.reefy.instance_uuid': 'app-a',
+                'com.docker.compose.project': 'reefy-app-a',
+                'exitCode': '0',
+            }},
+        }
+
+        with mock.patch.object(dataplane.threading, 'Thread') as thread:
+            self.assertFalse(self.dp._handle_docker_event(event))
+
+        thread.assert_not_called()
 
     def test_runtime_compose_strips_completed_init_and_dependency(self):
         compose = {'services': {
@@ -497,13 +863,14 @@ class AppsV2Tests(unittest.TestCase):
             self.assertEqual(
                 self.dp._run_app_init_services(
                     'reefy-app-a', compose, 'app-a'),
-                (True, []))
+                (True, {}, None))
             self.assertEqual(
                 self.dp._run_app_init_services(
                     'reefy-app-a', compose, 'app-a'),
-                (True, []))
+                (True, {}, None))
 
-        self.assertEqual(calls, [['run', '--rm', 'setup']])
+        self.assertEqual(calls, [
+            ['run', '--pull', 'never', '--rm', 'setup']])
 
     def test_optional_service_failure_keeps_app_running(self):
         compose = {'services': {
@@ -523,17 +890,1115 @@ class AppsV2Tests(unittest.TestCase):
             },
         }}
 
-        def apply(_project, _compose, instance_uuid=None,
-                  primary_service='app', services=None, **_kwargs):
-            return services != ['diagnostics']
+        def start(_path, _project, services, **_kwargs):
+            if services == ['diagnostics']:
+                return False, 'synthetic optional failure', (
+                    'docker compose up failed')
+            return True, '', ''
 
         with mock.patch.object(
-                self.dp, '_apply_project_compose', side_effect=apply), \
+                self.dp, '_pull_project_images',
+                return_value=(True, '', '')), \
+                mock.patch.object(
+                    self.dp, '_start_project_services', side_effect=start), \
                 mock.patch.object(self.dp, '_publish_health_status'):
             result = self.dp._apply_app_project_compose(
                 'reefy-app-a', compose, 'app-a', 'web')
 
         self.assertEqual(result, (True, ['diagnostics']))
+
+
+class AppsV2PullRecoveryTests(unittest.TestCase):
+    def setUp(self):
+        self.dp = _make_dp()
+        self.tempdir = tempfile.mkdtemp()
+        self.dp.DESIRED_STATE_PATH = os.path.join(
+            self.tempdir, 'desired-state.json')
+        self.dp.DESIRED_STATE_V2_PATH = os.path.join(
+            self.tempdir, 'desired-state-v2.json')
+        self.dp.COMPOSE_PATH = os.path.join(
+            self.tempdir, 'docker-compose.json')
+        self.dp.PROJECTS_DIR = os.path.join(self.tempdir, 'projects')
+
+    @staticmethod
+    def _health_statuses(health):
+        return [call.args[1] for call in health.call_args_list]
+
+    @staticmethod
+    def _compose_with_init():
+        return {'services': {
+            'seed': {'image': 'synthetic/seed:1'},
+            'setup': {
+                'image': 'synthetic/setup:1',
+                'labels': {'ai.reefy.lifecycle': 'init'},
+                'depends_on': {'seed': {'condition': 'service_started'}},
+            },
+            'app': {
+                'image': 'synthetic/app:1',
+                'depends_on': {
+                    'setup': {
+                        'condition': 'service_completed_successfully'},
+                    'seed': {'condition': 'service_started'},
+                },
+            },
+        }}
+
+    def _write_v2_state(self, compose=None):
+        compose = compose or {'services': {
+            'app': {'image': 'synthetic/app:1'},
+        }}
+        state = {
+            'schema_version': 2,
+            'apps': [{
+                'instance_uuid': 'synthetic-app',
+                'project_name': 'reefy-synthetic-app',
+                'primary_service': 'app',
+                'desired_status': 'running',
+                'compose': compose,
+                'artifacts': [],
+            }],
+        }
+        Path(self.dp.DESIRED_STATE_V2_PATH).write_text(json.dumps(state))
+        return state
+
+    def test_app_pipeline_pulls_before_init_and_start_with_explicit_flags(self):
+        compose = self._compose_with_init()
+        calls = []
+
+        def pull(_path, _project, args, timeout):
+            calls.append(('pull', args, timeout))
+            return True, 'pull complete'
+
+        def run(_path, _project, args, timeout):
+            calls.append((args[0], args, timeout))
+            return True, 'complete'
+
+        with mock.patch.object(
+                self.dp, '_run_compose_command_streaming',
+                side_effect=pull), \
+                mock.patch.object(
+                    self.dp, '_run_compose_command', side_effect=run), \
+                mock.patch.object(self.dp, '_publish_health_status') as health:
+            result = self.dp._apply_app_project_compose(
+                'reefy-synthetic-app', compose, 'synthetic-app', 'app')
+
+        self.assertEqual(result, (True, []))
+        self.assertEqual(calls[0][0], 'pull')
+        self.assertEqual(calls[0][1], [
+            'pull', '--policy', 'missing', 'app', 'seed', 'setup'])
+        self.assertLessEqual(calls[0][2], 3600)
+        self.assertGreater(calls[0][2], 3500)
+        self.assertEqual(calls[1][1], [
+            'run', '--pull', 'never', '--rm', 'setup'])
+        up = next(call for call in calls if call[0] == 'up')
+        self.assertEqual(up[1][:4], ['up', '-d', '--pull', 'never'])
+        self.assertIn('--remove-orphans', up[1])
+        self.assertLessEqual(up[2], 180)
+        statuses = [call.args[1] for call in health.call_args_list]
+        self.assertEqual(statuses[0], 'starting')
+        self.assertEqual(statuses[-1], 'running')
+
+    def test_pull_failure_skips_compose_up_and_persists_pull_phase(self):
+        compose = {'services': {'app': {'image': 'synthetic/missing:1'}}}
+        with mock.patch.object(
+                self.dp, '_run_compose_command_streaming',
+                return_value=(False, 'manifest unknown')) as pull, \
+                mock.patch.object(
+                    self.dp, '_run_compose_command') as run, \
+                mock.patch.object(self.dp, '_publish_health_status'):
+            self.assertFalse(self.dp._apply_project_compose(
+                'reefy-synthetic-app', compose,
+                instance_uuid='synthetic-app'))
+
+        pull.assert_called_once()
+        run.assert_not_called()
+        marker = self.dp._read_failed_sig_record(os.path.join(
+            self.dp.PROJECTS_DIR, 'reefy-synthetic-app',
+            '.failed-compose-sig'))
+        self.assertEqual(marker['phase'], 'pull')
+        self.assertEqual(marker['services'], ['app'])
+        self.assertEqual(
+            marker['reason'], 'image not found or access denied')
+
+    def test_pull_retries_share_one_monotonic_deadline(self):
+        clock = [0.0]
+        timeouts = []
+
+        def monotonic():
+            return clock[0]
+
+        def pull(*_args, **kwargs):
+            timeouts.append(kwargs['timeout'])
+            clock[0] += 100
+            return False, 'temporary registry timeout'
+
+        def sleep(delay):
+            clock[0] += delay
+
+        with mock.patch.object(
+                dataplane.time, 'monotonic', side_effect=monotonic), \
+                mock.patch.object(
+                    dataplane.time, 'sleep', side_effect=sleep), \
+                mock.patch.object(
+                    self.dp, '_run_compose_command_streaming',
+                    side_effect=pull):
+            ok, _output, reason = self.dp._pull_project_images(
+                '/synthetic/compose.json', 'reefy-synthetic-app', ['app'],
+                deadline=360, max_retries=5)
+
+        self.assertFalse(ok)
+        self.assertEqual(timeouts, [360, 250, 130])
+        self.assertEqual(clock[0], 360)
+        self.assertEqual(reason, 'docker compose pull timed out')
+
+    def test_deterministic_pull_failure_does_not_retry(self):
+        with mock.patch.object(
+                self.dp, '_run_compose_command_streaming',
+                return_value=(
+                    False, 'unauthorized: authentication required')) as pull, \
+                mock.patch.object(dataplane.time, 'sleep') as sleep:
+            ok, _output, reason = self.dp._pull_project_images(
+                '/synthetic/compose.json', 'reefy-synthetic-app', ['app'],
+                deadline=dataplane.time.monotonic() + 3600)
+
+        self.assertFalse(ok)
+        pull.assert_called_once()
+        sleep.assert_not_called()
+        self.assertEqual(reason, 'image not found or access denied')
+
+    def test_pull_no_space_and_storage_corruption_fail_without_prune(self):
+        cases = (
+            ('no space left on device', 'out of disk space'),
+            ('failed to register layer', 'docker storage error'),
+        )
+        for output, expected_reason in cases:
+            with self.subTest(output=output), \
+                    mock.patch.object(
+                        self.dp, '_run_compose_command_streaming',
+                        return_value=(False, output)) as pull, \
+                    mock.patch.object(self.dp, '_prune_docker') as prune, \
+                    mock.patch.object(dataplane.time, 'sleep') as sleep:
+                ok, _output, reason = self.dp._pull_project_images(
+                    '/synthetic/compose.json', 'reefy-synthetic-app',
+                    ['app'], deadline=dataplane.time.monotonic() + 3600)
+
+            self.assertFalse(ok)
+            pull.assert_called_once()
+            prune.assert_not_called()
+            sleep.assert_not_called()
+            self.assertEqual(reason, expected_reason)
+
+    def test_start_retries_share_180_second_deadline(self):
+        clock = [0.0]
+        timeouts = []
+
+        def monotonic():
+            return clock[0]
+
+        def run(*_args, **kwargs):
+            timeouts.append(kwargs['timeout'])
+            clock[0] += 100
+            return False, 'temporary daemon timeout'
+
+        def sleep(delay):
+            clock[0] += delay
+
+        with mock.patch.object(
+                dataplane.time, 'monotonic', side_effect=monotonic), \
+                mock.patch.object(
+                    dataplane.time, 'sleep', side_effect=sleep), \
+                mock.patch.object(
+                    self.dp, '_run_compose_command', side_effect=run):
+            ok, _output, reason = self.dp._start_project_services(
+                '/synthetic/compose.json', 'reefy-synthetic-app', ['app'])
+
+        self.assertFalse(ok)
+        self.assertEqual(timeouts, [180, 70])
+        self.assertGreaterEqual(clock[0], 180)
+        self.assertEqual(reason, 'docker compose up timed out')
+
+    def test_start_deterministic_failures_do_not_backoff(self):
+        cases = (
+            ('manifest unknown', 'image not found or access denied'),
+            ('no space left on device', 'out of disk space'),
+            ('failed to register layer', 'docker storage error'),
+        )
+        for output, expected_reason in cases:
+            with self.subTest(output=output), \
+                    mock.patch.object(
+                        self.dp, '_run_compose_command',
+                        return_value=(False, output)) as run, \
+                    mock.patch.object(dataplane.time, 'sleep') as sleep:
+                ok, _output, reason = self.dp._start_project_services(
+                    '/synthetic/compose.json', 'reefy-synthetic-app',
+                    ['app'])
+
+            self.assertFalse(ok)
+            run.assert_called_once()
+            sleep.assert_not_called()
+            self.assertEqual(reason, expected_reason)
+
+    def test_completed_required_and_optional_init_images_are_not_pulled(self):
+        compose = self._compose_with_init()
+        compose['services']['optional-setup'] = {
+            'image': 'synthetic/optional-setup:1',
+            'labels': {
+                'ai.reefy.lifecycle': 'init',
+                'ai.reefy.optional': 'true',
+            },
+        }
+        project_name = 'reefy-synthetic-app'
+        project_dir = Path(self.dp.PROJECTS_DIR) / project_name
+        project_dir.mkdir(parents=True)
+        for service_name in ('setup', 'optional-setup'):
+            signature = self.dp._compose_sig({
+                'service': service_name,
+                'definition': compose['services'][service_name],
+            })
+            (project_dir / f'.init-{service_name}.sig').write_text(
+                signature + '\n')
+        pulled = []
+
+        def pull(_path, _project, services, _deadline, **_kwargs):
+            pulled.append(services)
+            return True, '', ''
+
+        with mock.patch.object(
+                self.dp, '_pull_project_images', side_effect=pull), \
+                mock.patch.object(self.dp, '_publish_health_status'):
+            prepared = self.dp._prepare_app_project_compose(
+                project_name, compose, 'synthetic-app', 'app')
+
+        self.assertTrue(prepared['ok'])
+        self.assertEqual(pulled, [['app', 'seed']])
+        self.assertNotIn('setup', pulled[0])
+        self.assertNotIn('optional-setup', pulled[0])
+
+    def test_pending_init_pull_includes_its_dependencies(self):
+        plan = self.dp._app_project_plan(
+            'reefy-synthetic-app', self._compose_with_init(), 'app')
+        self.assertEqual(plan['required_services'], [
+            'app', 'seed', 'setup'])
+
+    def test_completed_init_is_absent_from_pull_and_pending_run_compose(self):
+        compose = {'services': {
+            'bootstrap': {
+                'image': 'synthetic/bootstrap:1',
+                'labels': {'ai.reefy.lifecycle': 'init'},
+            },
+            'migrate': {
+                'image': 'synthetic/migrate:1',
+                'labels': {'ai.reefy.lifecycle': 'init'},
+                'depends_on': {
+                    'bootstrap': {
+                        'condition': 'service_completed_successfully'},
+                },
+            },
+            'app': {'image': 'synthetic/app:1'},
+        }}
+        project_name = 'reefy-synthetic-app'
+        project_dir = Path(self.dp.PROJECTS_DIR) / project_name
+        project_dir.mkdir(parents=True)
+        signature = self.dp._init_service_signature(
+            'bootstrap', compose['services']['bootstrap'])
+        (project_dir / '.init-bootstrap.sig').write_text(signature + '\n')
+
+        plan = self.dp._app_project_plan(project_name, compose, 'app')
+        self.assertEqual(plan['required_services'], ['app', 'migrate'])
+        run_composes = []
+        run_services = []
+
+        def run(compose_path, _project, args, timeout):
+            run_composes.append(json.loads(Path(compose_path).read_text()))
+            run_services.append(args[-1])
+            return True, ''
+
+        with mock.patch.object(
+                self.dp, '_run_compose_command', side_effect=run), \
+                mock.patch.object(self.dp, '_publish_health_status'):
+            result = self.dp._run_app_init_services(
+                project_name, compose, 'synthetic-app',
+                required_init_services=plan['required_init_services'])
+
+        self.assertEqual(result, (True, {}, None))
+        self.assertEqual(run_services, ['migrate'])
+        self.assertNotIn('bootstrap', run_composes[0]['services'])
+        self.assertNotIn(
+            'depends_on', run_composes[0]['services']['migrate'])
+
+    def test_optional_init_in_required_closure_is_required(self):
+        relationships = ('required_init', 'required_runtime')
+        for relationship in relationships:
+            with self.subTest(relationship=relationship):
+                bootstrap = {
+                    'image': 'synthetic/bootstrap:1',
+                    'labels': {
+                        'ai.reefy.lifecycle': 'init',
+                        'ai.reefy.optional': 'true',
+                    },
+                }
+                services = {
+                    'bootstrap': bootstrap,
+                    'app': {'image': 'synthetic/app:1'},
+                }
+                if relationship == 'required_init':
+                    services['migrate'] = {
+                        'image': 'synthetic/migrate:1',
+                        'labels': {'ai.reefy.lifecycle': 'init'},
+                        'depends_on': ['bootstrap'],
+                    }
+                else:
+                    services['app']['depends_on'] = ['bootstrap']
+                compose = {'services': services}
+                project_name = f'reefy-synthetic-{relationship}'
+                plan = self.dp._app_project_plan(
+                    project_name, compose, 'app')
+
+                self.assertIn('bootstrap', plan['required_services'])
+                self.assertIn(
+                    'bootstrap', plan['required_init_services'])
+                self.assertNotIn(
+                    'bootstrap', [entry['name']
+                                  for entry in plan['optional']])
+
+                init_calls = []
+
+                def run(_path, _project, args, timeout):
+                    init_calls.append(args[-1])
+                    if args[-1] == 'bootstrap':
+                        return False, 'synthetic bootstrap failure'
+                    return True, ''
+
+                with mock.patch.object(
+                        self.dp, '_pull_project_images',
+                        return_value=(True, '', '')), \
+                        mock.patch.object(
+                            self.dp, '_run_compose_command', side_effect=run), \
+                        mock.patch.object(
+                            self.dp, '_start_project_services') as start, \
+                        mock.patch.object(
+                            self.dp, '_publish_health_status') as health:
+                    result = self.dp._apply_app_project_compose(
+                        project_name, compose, 'synthetic-app', 'app')
+
+                self.assertEqual(result, (False, []))
+                self.assertEqual(init_calls, ['bootstrap'])
+                start.assert_not_called()
+                statuses = self._health_statuses(health)
+                self.assertEqual(statuses.count('failed'), 1)
+                self.assertNotIn('running', statuses)
+
+    def test_optional_pull_failure_does_not_block_required_start(self):
+        compose = {'services': {
+            'app': {'image': 'synthetic/app:1'},
+            'diagnostics': {
+                'image': 'synthetic/diagnostics:1',
+                'labels': {'ai.reefy.optional': 'true'},
+            },
+        }}
+
+        def pull(_path, _project, services, _deadline, **_kwargs):
+            if services == ['diagnostics']:
+                return False, 'temporary registry timeout', (
+                    'docker compose pull failed')
+            return True, '', ''
+
+        with mock.patch.object(
+                self.dp, '_pull_project_images', side_effect=pull), \
+                mock.patch.object(self.dp, '_publish_health_status'):
+            prepared = self.dp._prepare_app_project_compose(
+                'reefy-synthetic-app', compose,
+                'synthetic-app', 'app')
+
+        self.assertTrue(prepared['ok'])
+        self.assertIn('diagnostics', prepared['optional_failures'])
+        marker = self.dp._read_failed_sig_record(os.path.join(
+            self.dp.PROJECTS_DIR, 'reefy-synthetic-app',
+            '.failed-compose-sig.optional-diagnostics'))
+        self.assertEqual(marker['phase'], 'pull')
+        self.assertFalse(os.path.exists(os.path.join(
+            self.dp.PROJECTS_DIR, 'reefy-synthetic-app',
+            '.failed-compose-sig')))
+
+    def test_optional_runtime_does_not_start_after_init_dependency_fails(self):
+        compose = {'services': {
+            'app': {'image': 'synthetic/app:1'},
+            'setup': {
+                'image': 'synthetic/setup:1',
+                'labels': {
+                    'ai.reefy.lifecycle': 'init',
+                    'ai.reefy.optional': 'true',
+                },
+            },
+            'diagnostics': {
+                'image': 'synthetic/diagnostics:1',
+                'labels': {'ai.reefy.optional': 'true'},
+                'depends_on': {
+                    'setup': {
+                        'condition': 'service_completed_successfully'},
+                },
+            },
+        }}
+        starts = []
+
+        def run(_path, _project, args, timeout):
+            self.assertEqual(args[-1], 'setup')
+            return False, 'synthetic setup failure'
+
+        def start(_path, _project, services, **_kwargs):
+            starts.append(services)
+            return True, '', ''
+
+        with mock.patch.object(
+                self.dp, '_pull_project_images',
+                return_value=(True, '', '')), \
+                mock.patch.object(
+                    self.dp, '_run_compose_command', side_effect=run), \
+                mock.patch.object(
+                    self.dp, '_start_project_services', side_effect=start), \
+                mock.patch.object(
+                    self.dp, '_publish_health_status') as health:
+            result = self.dp._apply_app_project_compose(
+                'reefy-synthetic-app', compose,
+                'synthetic-app', 'app')
+
+        self.assertEqual(result, (True, ['diagnostics', 'setup']))
+        self.assertEqual(starts, [['app']])
+        diagnostics_marker = self.dp._read_failed_sig_record(os.path.join(
+            self.dp.PROJECTS_DIR, 'reefy-synthetic-app',
+            '.failed-compose-sig.optional-diagnostics'))
+        self.assertEqual(diagnostics_marker['phase'], 'init')
+        statuses = self._health_statuses(health)
+        self.assertEqual(statuses.count('running'), 1)
+        self.assertEqual(statuses.count('failed'), 0)
+
+    def test_legacy_optional_runtime_marker_still_skips_retry(self):
+        compose = {'services': {
+            'app': {'image': 'synthetic/app:1'},
+            'setup': {
+                'image': 'synthetic/setup:1',
+                'labels': {
+                    'ai.reefy.lifecycle': 'init',
+                    'ai.reefy.optional': 'true',
+                },
+            },
+            'diagnostics': {
+                'image': 'synthetic/diagnostics:1',
+                'labels': {'ai.reefy.optional': 'true'},
+                'depends_on': ['setup'],
+            },
+        }}
+        project_name = 'reefy-synthetic-app'
+        runtime = self.dp._runtime_app_compose(compose)
+        legacy_signature = self.dp._compose_sig({
+            'compose': runtime,
+            'services': ['diagnostics'],
+        })
+        marker_path = Path(self.dp.PROJECTS_DIR) / project_name / (
+            '.failed-compose-sig.optional-diagnostics')
+        marker_path.parent.mkdir(parents=True)
+        marker_path.write_text(
+            legacy_signature + '\nsynthetic legacy optional failure')
+        pulls = []
+        starts = []
+
+        def pull(_path, _project, services, _deadline, **_kwargs):
+            pulls.append(services)
+            return True, '', ''
+
+        def start(_path, _project, services, **_kwargs):
+            starts.append(services)
+            return True, '', ''
+
+        with mock.patch.object(
+                self.dp, '_pull_project_images', side_effect=pull), \
+                mock.patch.object(
+                    self.dp, '_run_compose_command', return_value=(True, '')), \
+                mock.patch.object(
+                    self.dp, '_start_project_services', side_effect=start), \
+                mock.patch.object(self.dp, '_publish_health_status'):
+            result = self.dp._apply_app_project_compose(
+                project_name, compose, 'synthetic-app', 'app')
+
+        self.assertEqual(result, (True, ['diagnostics']))
+        self.assertEqual(pulls, [['app'], ['setup']])
+        self.assertEqual(starts, [['app']])
+        self.assertTrue(marker_path.exists())
+
+    def test_failure_marker_is_atomic_json_and_reads_legacy_format(self):
+        marker_path = os.path.join(
+            self.tempdir, 'project', '.failed-compose-sig')
+        os.makedirs(os.path.dirname(marker_path))
+        Path(marker_path).write_text('legacy-signature\nlegacy reason')
+        legacy = self.dp._read_failed_sig_record(marker_path)
+        self.assertEqual(legacy['version'], 1)
+        self.assertEqual(legacy['phase'], 'legacy')
+        self.assertEqual(legacy['reason'], 'legacy reason')
+
+        with mock.patch.object(
+                dataplane.os, 'replace', wraps=os.replace) as replace:
+            self.dp._write_failed_sig_path(
+                marker_path, 'current-signature',
+                'password=synthetic-private-value',
+                phase='init', services=['setup', 'app'])
+        replace.assert_called_once_with(marker_path + '.tmp', marker_path)
+        current = json.loads(Path(marker_path).read_text())
+        self.assertEqual(current['version'], 2)
+        self.assertEqual(current['phase'], 'init')
+        self.assertEqual(current['services'], ['app', 'setup'])
+        self.assertEqual(current['reason'], 'password=[REDACTED]')
+        self.assertNotIn('synthetic-private-value', Path(marker_path).read_text())
+        self.assertFalse(os.path.exists(marker_path + '.tmp'))
+
+        old_content = Path(marker_path).read_text()
+        with mock.patch.object(
+                dataplane.os, 'replace', side_effect=OSError('synthetic')), \
+                mock.patch.object(dataplane, 'log'):
+            self.dp._write_failed_sig_path(
+                marker_path, 'replacement-signature', 'replacement reason',
+                phase='pull', services=['app'])
+        self.assertEqual(Path(marker_path).read_text(), old_content)
+        self.assertFalse(os.path.exists(marker_path + '.tmp'))
+
+    def test_retry_recovers_each_current_required_failure_phase(self):
+        compose = {'services': {'app': {'image': 'synthetic/app:1'}}}
+        self._write_v2_state(compose)
+        project_name = 'reefy-synthetic-app'
+        context = self.dp._failure_marker_context(
+            project_name, compose, ['app'])
+        other_dir = Path(self.dp.PROJECTS_DIR) / 'reefy-other-app'
+        other_dir.mkdir(parents=True)
+        other_marker = other_dir / '.failed-compose-sig'
+        other_marker.write_text('other-signature\nother reason')
+
+        for phase in ('pull', 'init', 'start'):
+            with self.subTest(phase=phase):
+                self.dp._write_failed_sig_path(
+                    context['path'], context['signature'],
+                    'synthetic required failure', phase=phase,
+                    services=['app'])
+                optional_path = context['path'] + '.optional-diagnostics'
+                self.dp._write_failed_sig_path(
+                    optional_path, 'optional-signature',
+                    'synthetic optional failure', phase='pull',
+                    services=['diagnostics'])
+                with mock.patch.object(
+                        self.dp, '_pull_project_images',
+                        return_value=(True, '', '')), \
+                        mock.patch.object(
+                            self.dp, '_start_project_services',
+                            return_value=(True, '', '')), \
+                        mock.patch.object(
+                            self.dp, '_publish_health_status') as health, \
+                        mock.patch.object(
+                            dataplane.subprocess, 'run') as healthy_restart:
+                    message = self.dp._restart_instance({
+                        'instance_uuid': 'synthetic-app'})
+
+                self.assertEqual(
+                    message, 'Instance synthetic-app restarted')
+                healthy_restart.assert_not_called()
+                self.assertFalse(os.path.exists(context['path']))
+                self.assertFalse(os.path.exists(optional_path))
+                self.assertTrue(other_marker.exists())
+                statuses = [call.args[1] for call in health.call_args_list]
+                self.assertIn('starting', statuses)
+                self.assertEqual(statuses[-1], 'running')
+
+    def test_pending_migration_required_retry_uses_full_serialized_job(self):
+        compose = {'services': {'app': {'image': 'synthetic/app:1'}}}
+        self._write_v2_state(compose)
+        Path(self.dp.DESIRED_STATE_PATH).write_text('{}')
+        project_name = 'reefy-synthetic-app'
+        context = self.dp._required_app_failure_context(
+            project_name, compose, 'app')
+        self.dp._write_failed_sig_path(
+            context['path'], context['signature'], 'synthetic pull failure',
+            phase='pull', services=context['services'])
+        migration_marker = Path(self.tempdir) / 'apps-v2-migrated'
+
+        def wait(_request_id):
+            self.dp._clear_failed_sig_path(context['path'])
+            migration_marker.write_text('2\n')
+            return {
+                'status': 'succeeded',
+                'error': '',
+                'warnings': [],
+            }
+
+        with mock.patch.object(
+                self.dp, '_submit_apply_job',
+                return_value={
+                    'ok': True, 'request_id': 'synthetic-request',
+                    'error': '',
+                }) as submit, \
+                mock.patch.object(
+                    self.dp, '_wait_apply_result', side_effect=wait), \
+                mock.patch.object(
+                    self.dp, '_apply_app_project_compose') as direct_apply, \
+                mock.patch.object(dataplane.subprocess, 'run') as direct_run:
+            message = self.dp._restart_instance({
+                'instance_uuid': 'synthetic-app'})
+
+        self.assertEqual(message, 'Instance synthetic-app restarted')
+        submit.assert_called_once_with(
+            'reconcile',
+            force_retry={
+                'project_name': project_name,
+                'signature': context['signature'],
+            },
+            wait_for_idle=True)
+        direct_apply.assert_not_called()
+        direct_run.assert_not_called()
+
+    def test_pending_migration_healthy_and_optional_restart_reject(self):
+        compose = {'services': {
+            'app': {'image': 'synthetic/app:1'},
+            'diagnostics': {
+                'image': 'synthetic/diagnostics:1',
+                'labels': {'ai.reefy.optional': 'true'},
+            },
+        }}
+        self._write_v2_state(compose)
+        Path(self.dp.DESIRED_STATE_PATH).write_text('{}')
+        project_name = 'reefy-synthetic-app'
+        project_dir = Path(self.dp.PROJECTS_DIR) / project_name
+        project_dir.mkdir(parents=True)
+
+        for optional_marker in (False, True):
+            with self.subTest(optional_marker=optional_marker):
+                optional_path = project_dir / (
+                    '.failed-compose-sig.optional-diagnostics')
+                if optional_marker:
+                    optional_path.write_text(
+                        'synthetic-signature\nsynthetic optional failure')
+                else:
+                    optional_path.unlink(missing_ok=True)
+                with mock.patch.object(
+                        self.dp, '_submit_apply_job') as submit, \
+                        mock.patch.object(
+                            self.dp, '_apply_app_project_compose') as apply, \
+                        mock.patch.object(
+                            dataplane.subprocess, 'run') as run:
+                    with self.assertRaisesRegex(
+                            RuntimeError, 'migration is in progress'):
+                        self.dp._restart_instance({
+                            'instance_uuid': 'synthetic-app'})
+
+                submit.assert_not_called()
+                apply.assert_not_called()
+                run.assert_not_called()
+                if optional_marker:
+                    self.assertTrue(optional_path.exists())
+
+    def test_force_retry_clears_only_matching_current_signature(self):
+        compose = {'services': {'app': {'image': 'synthetic/app:1'}}}
+        project_name = 'reefy-synthetic-app'
+        context = self.dp._required_app_failure_context(
+            project_name, compose, 'app')
+        self.dp._write_failed_sig_path(
+            context['path'], context['signature'], 'synthetic failure',
+            phase='pull', services=context['services'])
+
+        with mock.patch.object(
+                self.dp, '_pull_project_images') as pull, \
+                mock.patch.object(self.dp, '_publish_health_status'):
+            stale = self.dp._prepare_app_project_compose(
+                project_name, compose, 'synthetic-app', 'app',
+                force_retry=True, force_retry_signature='stale-signature')
+        self.assertFalse(stale['ok'])
+        pull.assert_not_called()
+        self.assertTrue(os.path.exists(context['path']))
+
+        with mock.patch.object(
+                self.dp, '_pull_project_images',
+                return_value=(True, '', '')) as pull, \
+                mock.patch.object(self.dp, '_publish_health_status'):
+            current = self.dp._prepare_app_project_compose(
+                project_name, compose, 'synthetic-app', 'app',
+                force_retry=True,
+                force_retry_signature=context['signature'])
+        self.assertTrue(current['ok'])
+        pull.assert_called_once()
+        self.assertFalse(os.path.exists(context['path']))
+
+    def test_optional_marker_keeps_healthy_primary_only_restart(self):
+        compose = {'services': {
+            'app': {'image': 'synthetic/app:1'},
+            'diagnostics': {
+                'image': 'synthetic/diagnostics:1',
+                'labels': {'ai.reefy.optional': 'true'},
+            },
+        }}
+        self._write_v2_state(compose)
+        compose_path = self.dp._write_project_compose(
+            'reefy-synthetic-app', compose)
+        optional_path = os.path.join(
+            os.path.dirname(compose_path),
+            '.failed-compose-sig.optional-diagnostics')
+        Path(optional_path).write_text(
+            'optional-signature\nsynthetic optional failure')
+        result = mock.Mock(returncode=0, stdout='', stderr='')
+
+        with mock.patch.object(
+                dataplane.subprocess, 'run', return_value=result) as run, \
+                mock.patch.object(
+                    self.dp, '_apply_app_project_compose') as recovery:
+            self.dp._restart_instance({'instance_uuid': 'synthetic-app'})
+
+        recovery.assert_not_called()
+        self.assertEqual(run.call_args.args[0], [
+            'docker', 'compose', '-f', compose_path, '-p',
+            'reefy-synthetic-app', 'up', '-d', '--force-recreate',
+            '--no-deps', 'app'])
+        self.assertTrue(os.path.exists(optional_path))
+
+    def test_required_failure_phases_publish_one_terminal_failed(self):
+        for phase in ('pull', 'init', 'start'):
+            with self.subTest(phase=phase):
+                project_name = f'reefy-synthetic-{phase}'
+                compose = {'services': {
+                    'app': {'image': 'synthetic/app:1'},
+                }}
+                if phase == 'init':
+                    compose['services']['setup'] = {
+                        'image': 'synthetic/setup:1',
+                        'labels': {'ai.reefy.lifecycle': 'init'},
+                    }
+
+                def pull(*_args, **_kwargs):
+                    if phase == 'pull':
+                        return False, 'manifest unknown', (
+                            'image not found or access denied')
+                    return True, '', ''
+
+                def run(_path, _project, args, timeout):
+                    if phase == 'init' and args[0] == 'run':
+                        return False, 'synthetic init failure'
+                    return True, ''
+
+                def start(*_args, **_kwargs):
+                    if phase == 'start':
+                        return False, 'synthetic start failure', (
+                            'docker compose up failed')
+                    return True, '', ''
+
+                with mock.patch.object(
+                        self.dp, '_pull_project_images', side_effect=pull), \
+                        mock.patch.object(
+                            self.dp, '_run_compose_command', side_effect=run), \
+                        mock.patch.object(
+                            self.dp, '_start_project_services',
+                            side_effect=start), \
+                        mock.patch.object(
+                            self.dp, '_publish_health_status') as health:
+                    result = self.dp._apply_app_project_compose(
+                        project_name, compose, 'synthetic-app', 'app')
+
+                self.assertEqual(result[0], False)
+                statuses = self._health_statuses(health)
+                self.assertEqual(statuses.count('failed'), 1)
+                self.assertEqual(statuses.count('running'), 0)
+                self.assertEqual(statuses[-1], 'failed')
+
+    def test_optional_failure_success_has_one_running_and_no_failed(self):
+        compose = {'services': {
+            'app': {'image': 'synthetic/app:1'},
+            'diagnostics': {
+                'image': 'synthetic/diagnostics:1',
+                'labels': {'ai.reefy.optional': 'true'},
+            },
+        }}
+
+        def pull(_path, _project, services, _deadline, **_kwargs):
+            if services == ['diagnostics']:
+                return False, 'manifest unknown', (
+                    'image not found or access denied')
+            return True, '', ''
+
+        with mock.patch.object(
+                self.dp, '_pull_project_images', side_effect=pull), \
+                mock.patch.object(
+                    self.dp, '_start_project_services',
+                    return_value=(True, '', '')), \
+                mock.patch.object(
+                    self.dp, '_publish_health_status') as health:
+            result = self.dp._apply_app_project_compose(
+                'reefy-synthetic-app', compose, 'synthetic-app', 'app')
+
+        self.assertEqual(result, (True, ['diagnostics']))
+        statuses = self._health_statuses(health)
+        self.assertEqual(statuses.count('running'), 1)
+        self.assertEqual(statuses.count('failed'), 0)
+        self.assertEqual(statuses[-1], 'running')
+
+    def test_sticky_skip_publishes_failed_without_starting(self):
+        compose = {'services': {'app': {'image': 'synthetic/app:1'}}}
+        project_name = 'reefy-synthetic-app'
+        context = self.dp._required_app_failure_context(
+            project_name, compose, 'app')
+        self.dp._write_failed_sig_path(
+            context['path'], context['signature'], 'synthetic failure',
+            phase='pull', services=context['services'])
+
+        with mock.patch.object(
+                self.dp, '_pull_project_images') as pull, \
+                mock.patch.object(
+                    self.dp, '_publish_health_status') as health:
+            result = self.dp._apply_app_project_compose(
+                project_name, compose, 'synthetic-app', 'app')
+
+        self.assertEqual(result, (False, []))
+        pull.assert_not_called()
+        self.assertEqual(self._health_statuses(health), ['failed'])
+
+    def test_multiple_init_progress_events_end_in_one_running(self):
+        compose = {'services': {
+            'first': {
+                'image': 'synthetic/first:1',
+                'labels': {'ai.reefy.lifecycle': 'init'},
+            },
+            'second': {
+                'image': 'synthetic/second:1',
+                'labels': {'ai.reefy.lifecycle': 'init'},
+                'depends_on': ['first'],
+            },
+            'app': {'image': 'synthetic/app:1'},
+        }}
+        with mock.patch.object(
+                self.dp, '_pull_project_images',
+                return_value=(True, '', '')), \
+                mock.patch.object(
+                    self.dp, '_run_compose_command',
+                    return_value=(True, '')), \
+                mock.patch.object(
+                    self.dp, '_start_project_services',
+                    return_value=(True, '', '')), \
+                mock.patch.object(
+                    self.dp, '_publish_health_status') as health:
+            result = self.dp._apply_app_project_compose(
+                'reefy-synthetic-app', compose,
+                'synthetic-app', 'app')
+
+        self.assertEqual(result, (True, []))
+        statuses = self._health_statuses(health)
+        self.assertEqual(statuses.count('starting'), 3)
+        self.assertEqual(statuses.count('running'), 1)
+        self.assertEqual(statuses.count('failed'), 0)
+
+    def test_different_project_apply_pulls_overlap(self):
+        barrier = threading.Barrier(2)
+        entered = []
+        results = []
+
+        def pull(_path, project_name, *_args, **_kwargs):
+            entered.append(project_name)
+            barrier.wait(timeout=2)
+            return True, '', ''
+
+        def apply(project_name):
+            results.append(self.dp._apply_project_compose(
+                project_name,
+                {'services': {'app': {'image': 'synthetic/app:1'}}}))
+
+        with mock.patch.object(
+                self.dp, '_pull_project_images', side_effect=pull), \
+                mock.patch.object(
+                    self.dp, '_start_project_services',
+                    return_value=(True, '', '')):
+            threads = [
+                threading.Thread(target=apply, args=(project_name,))
+                for project_name in (
+                    'reefy-synthetic-a', 'reefy-synthetic-b')
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=3)
+
+        self.assertTrue(all(not thread.is_alive() for thread in threads))
+        self.assertCountEqual(
+            entered, ['reefy-synthetic-a', 'reefy-synthetic-b'])
+        self.assertEqual(results, [True, True])
+
+    def test_same_project_apply_lock_serializes_pull_and_start(self):
+        first_entered = threading.Event()
+        release_first = threading.Event()
+        calls = []
+
+        def pull(*_args, **_kwargs):
+            calls.append('pull')
+            if len(calls) == 1:
+                first_entered.set()
+                self.assertTrue(release_first.wait(timeout=2))
+            return True, '', ''
+
+        results = []
+
+        def apply():
+            results.append(self.dp._apply_project_compose(
+                'reefy-synthetic-app',
+                {'services': {'app': {'image': 'synthetic/app:1'}}}))
+
+        with mock.patch.object(
+                self.dp, '_pull_project_images', side_effect=pull), \
+                mock.patch.object(
+                    self.dp, '_start_project_services',
+                    return_value=(True, '', '')):
+            first = threading.Thread(target=apply)
+            second = threading.Thread(target=apply)
+            first.start()
+            self.assertTrue(first_entered.wait(timeout=1))
+            second.start()
+            self.assertEqual(calls, ['pull'])
+            release_first.set()
+            first.join(timeout=2)
+            second.join(timeout=2)
+
+        self.assertFalse(first.is_alive())
+        self.assertFalse(second.is_alive())
+        self.assertEqual(calls, ['pull', 'pull'])
+        self.assertEqual(results, [True, True])
+
+    def test_streaming_timeout_keeps_partial_output_and_bounds_tail(self):
+        real_popen = dataplane.subprocess.Popen
+        script = (
+            'import os,time; '
+            'os.write(1, b"partial-output-without-newline" + b"x"*20000); '
+            'time.sleep(5)')
+
+        def popen(_command, **kwargs):
+            return real_popen([sys.executable, '-c', script], **kwargs)
+
+        with mock.patch.object(
+                dataplane.subprocess, 'Popen', side_effect=popen), \
+                mock.patch.object(dataplane, 'log'):
+            ok, output = self.dp._run_compose_command_streaming(
+                '/synthetic/compose.json', 'reefy-synthetic-app',
+                ['pull', '--policy', 'missing', 'app'], timeout=0.5)
+
+        self.assertFalse(ok)
+        self.assertIn('partial-output-without-newline', output)
+        self.assertIn('[truncated]', output)
+        self.assertIn('timed out', output)
+        self.assertLess(
+            len(output),
+            self.dp.COMPOSE_OUTPUT_TAIL_LINES
+            * (self.dp.COMPOSE_OUTPUT_LINE_CHARS + 100))
+
+    def test_streaming_truncation_redacts_boundary_spanning_secret(self):
+        real_popen = dataplane.subprocess.Popen
+        marker = ' [truncated]'
+        retained = self.dp.COMPOSE_OUTPUT_LINE_CHARS - len(marker)
+        secret = 'synthetic-boundary-secret-remainder'
+        line = (
+            'x' * (retained - len(' password=') - 4)
+            + ' password=' + secret)
+        script = (
+            'import os; '
+            f'os.write(1, {line.encode()!r})')
+
+        def popen(_command, **kwargs):
+            return real_popen([sys.executable, '-c', script], **kwargs)
+
+        with mock.patch.object(
+                dataplane.subprocess, 'Popen', side_effect=popen), \
+                mock.patch.object(dataplane, 'log') as logger:
+            ok, output = self.dp._run_compose_command_streaming(
+                '/synthetic/compose.json', 'reefy-synthetic-app',
+                ['pull', '--policy', 'missing', 'app'], timeout=5)
+
+        self.assertTrue(ok)
+        logged = '\n'.join(
+            str(call.args[1]) for call in logger.call_args_list)
+        for rendered in (logged, output):
+            self.assertIn('password=[REDACTED]', rendered)
+            self.assertIn('[truncated]', rendered)
+            self.assertNotIn(secret, rendered)
+            self.assertNotIn('boundary-secret-remainder', rendered)
+
+    def test_streaming_preserves_early_failure_classification_signals(self):
+        real_popen = dataplane.subprocess.Popen
+        cases = (
+            ('manifest unknown', 'image_missing'),
+            ('no space left on device', 'no_space'),
+        )
+        for signal_text, expected in cases:
+            script = (
+                'import sys; '
+                f'print({signal_text!r}); '
+                '[print(f"progress {index}") for index in range(300)]; '
+                'sys.exit(1)')
+
+            def popen(_command, **kwargs):
+                return real_popen([sys.executable, '-c', script], **kwargs)
+
+            with self.subTest(signal=signal_text), \
+                    mock.patch.object(
+                        dataplane.subprocess, 'Popen', side_effect=popen), \
+                    mock.patch.object(dataplane, 'log'):
+                ok, output = self.dp._run_compose_command_streaming(
+                    '/synthetic/compose.json', 'reefy-synthetic-app',
+                    ['pull', '--policy', 'missing', 'app'], timeout=5)
+
+            self.assertFalse(ok)
+            self.assertIn(signal_text, output)
+            self.assertEqual(
+                self.dp._classify_compose_failure(output), expected)
+            self.assertLessEqual(
+                len(output.splitlines()),
+                self.dp.COMPOSE_OUTPUT_TAIL_LINES + 1)
+
+    def test_streaming_classifies_signal_after_truncated_cr_progress(self):
+        real_popen = dataplane.subprocess.Popen
+        script = (
+            'import os,sys; '
+            'os.write(1, b"x"*5000 + b"\\rmanifest unknown\\r"); '
+            'sys.exit(1)')
+
+        def popen(_command, **kwargs):
+            return real_popen([sys.executable, '-c', script], **kwargs)
+
+        with mock.patch.object(
+                dataplane.subprocess, 'Popen', side_effect=popen), \
+                mock.patch.object(dataplane, 'log'):
+            ok, output = self.dp._run_compose_command_streaming(
+                '/synthetic/compose.json', 'reefy-synthetic-app',
+                ['pull', '--policy', 'missing', 'app'], timeout=5)
+
+        self.assertFalse(ok)
+        self.assertIn('manifest unknown', output)
+        self.assertEqual(
+            self.dp._classify_compose_failure(output), 'image_missing')
+        self.assertLessEqual(
+            len(output),
+            self.dp.COMPOSE_OUTPUT_TAIL_LINES
+            * (self.dp.COMPOSE_OUTPUT_LINE_CHARS + 100))
+
+    def test_classified_reason_is_kept_in_published_bounded_tail(self):
+        output = '\n'.join([
+            'manifest unknown',
+            *[f'progress {index}' for index in range(300)],
+        ])
+        rendered = self.dp._bounded_output_tail(
+            output, 'image not found or access denied')
+        self.assertEqual(
+            rendered.splitlines()[0],
+            'image not found or access denied')
+        self.assertLessEqual(len(rendered.splitlines()), 5)
+
+    def test_process_group_termination_escalates_and_waits(self):
+        proc = mock.Mock(pid=43210)
+        proc.wait.side_effect = [
+            dataplane.subprocess.TimeoutExpired(['docker'], 5), None]
+        with mock.patch.object(dataplane.os, 'killpg') as killpg:
+            self.dp._terminate_compose_process(proc)
+
+        self.assertEqual(killpg.call_args_list, [
+            mock.call(43210, dataplane.signal.SIGTERM),
+            mock.call(43210, dataplane.signal.SIGKILL),
+        ])
+        self.assertEqual(proc.wait.call_count, 2)
 
 
 class EventPublishingTests(unittest.TestCase):
@@ -800,6 +2265,79 @@ class ApplyPathTests(unittest.TestCase):
         self.assertEqual(active_result['status'], 'failed')
         self.assertEqual(pending_result['status'], 'succeeded')
         self.assertEqual(applied, ['active', 'pending'])
+
+    def test_wait_for_idle_retry_does_not_supersede_newer_pending_apply(self):
+        dp = _make_dp()
+        active_started = threading.Event()
+        release_active = threading.Event()
+        pending_started = threading.Event()
+        release_pending = threading.Event()
+        order = []
+        retry_submission = []
+
+        def apply(payload):
+            sequence = payload['state']['sequence']
+            order.append(sequence)
+            if sequence == 'active':
+                active_started.set()
+                self.assertTrue(release_active.wait(timeout=5))
+            if sequence == 'newer':
+                pending_started.set()
+                self.assertTrue(release_pending.wait(timeout=5))
+            return True
+
+        def reconcile(old_state=None, force_retry=None):
+            order.append(('retry', force_retry))
+            return True
+
+        def submit_retry():
+            submission = dp._submit_apply_job(
+                'reconcile',
+                force_retry={
+                    'project_name': 'reefy-synthetic-app',
+                    'signature': 'synthetic-signature',
+                },
+                wait_for_idle=True)
+            retry_submission.append(submission)
+
+        with mock.patch.object(dp, '_apply_state', side_effect=apply), \
+                mock.patch.object(
+                    dp, '_apply_desired_state', side_effect=reconcile):
+            active = dp._submit_apply_job(
+                'apply', state={'sequence': 'active'})
+            self.assertTrue(active_started.wait(timeout=5))
+            newer = dp._submit_apply_job(
+                'apply', state={'sequence': 'newer'})
+            retry_thread = threading.Thread(target=submit_retry)
+            retry_thread.start()
+            self.assertEqual(retry_submission, [])
+
+            release_active.set()
+            self.assertTrue(pending_started.wait(timeout=5))
+            self.assertEqual(
+                dp._get_apply_result(newer['request_id'])['status'],
+                'running')
+            self.assertEqual(retry_submission, [])
+            release_pending.set()
+            retry_thread.join(timeout=5)
+
+            active_result = dp._wait_apply_result(active['request_id'])
+            newer_result = dp._wait_apply_result(newer['request_id'])
+            retry_result = dp._wait_apply_result(
+                retry_submission[0]['request_id'])
+
+        self.assertFalse(retry_thread.is_alive())
+        self.assertEqual(active_result['status'], 'succeeded')
+        self.assertEqual(newer_result['status'], 'succeeded')
+        self.assertEqual(retry_result['status'], 'succeeded')
+        self.assertEqual(order, [
+            'active',
+            'newer',
+            ('retry', {
+                'project_name': 'reefy-synthetic-app',
+                'signature': 'synthetic-signature',
+            }),
+        ])
 
     def test_unknown_result_returns_found_false_without_waiting(self):
         dp = _make_dp()


### PR DESCRIPTION
## What changed

- split Apps-v2 image acquisition from startup with an explicit `docker compose pull --policy missing` phase and `up --pull never`
- give image pulls a shared one-hour budget with five transient retries while preserving the short startup timeout
- keep app projects isolated and remove automatic Docker prune from the new per-project path
- persist phase-aware failure markers and let the existing `restart_instance` command recover the matching failed project
- serialize migration retries and harden init dependencies, migration rollback, bounded redacted streaming, and terminal health publication

## Why

A slow first image download could outlive the previous Compose startup timeout and leave a project behind a sticky failure without an operator recovery path. Pulling and starting are now separate phases, so slow progress is allowed without coupling unrelated app projects.

## Impact

Healthy Restart behavior is unchanged. Failed Apps-v2 projects can be retried through the existing command after the dashboard capability gate is enabled. No new command, status, field, or manifest contract is introduced.

## Validation

- focused reconciler suite: 71 passed
- full Reefy OS suite: 341 passed
- independent adversarial probes: 8 passed
- dataplane suite: 120 passed
- Python compile and diff checks passed
