### PR TITLE
Pin Intel provider with host XPU-SMI

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -461,7 +461,7 @@ jobs:
 
   publish-intel-provider:
     needs: build
-    uses: reefyai/reefy-intel/.github/workflows/publish.yml@dd364f3897ae6c97455c389db8d9fb7982af2296
+    uses: reefyai/reefy-intel/.github/workflows/publish.yml@03b2e8fbaab93a7523613b08d237737e50a5e5ad
     with:
       input_artifact: reefy-intel-inputs
     secrets: inherit

--- a/board/reefy/reefy/tests/test_provider_workflow.py
+++ b/board/reefy/reefy/tests/test_provider_workflow.py
@@ -30,7 +30,7 @@ class ProviderWorkflowTests(unittest.TestCase):
             'reefyai/reefy-nvidia':
                 'bae37235695f797f86c05efc06daa0b927752a19',
             'reefyai/reefy-intel':
-                'dd364f3897ae6c97455c389db8d9fb7982af2296',
+                '03b2e8fbaab93a7523613b08d237737e50a5e5ad',
             'reefyai/reefy-amd':
                 'ccaf743c5dd77af5aaab91ee8300d1d5402ee1f9',
             'reefyai/reefy-artifact-fixtures':


### PR DESCRIPTION
## What changed

- pin the Intel provider reusable workflow to commit `03b2e8fbaab93a7523613b08d237737e50a5e5ad`
- update the immutable workflow reference test

## Why

The pinned provider revision adds stable Intel XPU-SMI 2.0.1 as a host-only, separately deduplicated tools layer. Application containers continue receiving only Intel CDI device nodes.

## Impact

Future firmware builds publish Intel provider version 3 artifacts with the new tools layer. Existing firmware and pinned provider digests remain unchanged.

## Validation

- `python3 -m unittest discover -s board/reefy/reefy/tests -v`
- 299 tests passed
- firmware and all provider publication jobs passed in run `31325022314`
- the signed provider catalog was generated successfully
- the dev firmware booted successfully through the A/B updater
